### PR TITLE
after_job() callback

### DIFF
--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -237,11 +237,12 @@ def pack_binary_command(cmd_type, cmd_args, is_response=False):
         magic = MAGIC_REQ_STRING
 
     # !NOTE! str should be replaced with bytes in Python 3.x
-    # We will iterate in ORDER and str all our command arguments
-    if compat.any(type(param_value) != str for param_value in cmd_args.itervalues()):
-        raise ProtocolError('Received non-binary arguments: %r' % cmd_args)
+    # The binary protocol is null byte delimited, so let's make sure we don't
+    # have null bytes in our values and we're dealing with strings we can probably encode.
+    if compat.any(not isinstance(param_value, basestring) or '\0' in param_value for param_value in cmd_args.itervalues()):
+        raise ProtocolError('Received un-encodable arguments: %r' % cmd_args)
 
-    data_items = [cmd_args[param] for param in expected_cmd_params]
+    data_items = [cmd_args[param].encode('ascii') for param in expected_cmd_params]
     binary_payload = NULL_CHAR.join(data_items)
 
     # Pack the header in the !4sII format then append the binary payload


### PR DESCRIPTION
I have a worker that I want to exit periodically.

Seemingly the way to do that would be to redefine after_poll() to check if the worker has been running too long, then return False so the worker will exit.

This has a subtle bug however. If the send_complete message has not yet been sent back to the server, the worker may exit before reporting the job's success or failure.

This pull request adds after_job(), which is called each time a job is no longer being handled, providing a much more useful hook for controlling the work loop.

My worker then does something like: 

<pre>
    def after_job(self):
        if time.time() - self.start_time > 10:
            log.info("Running for %d seconds, exiting", time.time() - self.start_time)
            return False
        
        return True
</pre>


There are no tests included. As far as I can tell (by inserting 'raise Exception()', that loop isn't tested anyway.
