### PR TITLE
Use weakrefs to avoid leaks

### DIFF
--- a/gearman/client.py
+++ b/gearman/client.py
@@ -3,6 +3,7 @@ from gearman import compat
 import logging
 import os
 import random
+import weakref
 
 import gearman.util
 
@@ -29,7 +30,7 @@ class GearmanClient(GearmanConnectionManager):
 
         # The authoritative copy of all requests that this client knows about
         # Ignores the fact if a request has been bound to a connection or not
-        self.request_to_rotating_connection_queue = compat.defaultdict(collections.deque)
+        self.request_to_rotating_connection_queue = weakref.WeakKeyDictionary(compat.defaultdict(collections.deque))
 
     def submit_job(self, task, data, unique=None, priority=PRIORITY_NONE, background=False, wait_until_complete=True, max_retries=0, poll_timeout=None):
         """Submit a single job to any gearman server"""

--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -1,6 +1,7 @@
 import collections
 import time
 import logging
+import weakref
 
 from gearman.command_handler import GearmanCommandHandler
 from gearman.constants import JOB_UNKNOWN, JOB_PENDING, JOB_CREATED, JOB_FAILED, JOB_COMPLETE
@@ -16,7 +17,7 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
 
         # When we first submit jobs, we don't have a handle assigned yet... these handles will be returned in the order of submission
         self.requests_awaiting_handles = collections.deque()
-        self.handle_to_request_map = dict()
+        self.handle_to_request_map = weakref.WeakValueDictionary()
 
     ##################################################################
     ##### Public interface methods to be called by GearmanClient #####


### PR DESCRIPTION
Dictionaries in client and client_handler keep references to GearmanJobRequest objects, but aren't explicitly removed until they either fail or complete.

This never occurs when wait_until_complete=False, so using WeakKeyDictionary and WeakValueDictionary ensures the request objects can be garbage collected.

Closes #10
