### PR TITLE
Add RetryJob exception to force a job retry

### DIFF
--- a/gearman/errors.py
+++ b/gearman/errors.py
@@ -24,3 +24,6 @@ class InvalidWorkerState(GearmanError):
 
 class InvalidAdminClientState(GearmanError):
     pass
+
+class RetryJob(Exception):
+    pass


### PR DESCRIPTION
Our current strategy for retrying work that fails because of transient issues (eg a DB error) is to sys.exit the worker and thus force gearman to retry the job. To avoid having to re-import and re-start the Python process, we added a custom Exception that can be thrown if the job is known to have failed for transient reasons.
