### PR TITLE
Fix exception / closed connection handling in poll_connections_until_stopped

### DIFF
--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -284,7 +284,7 @@ class ClientTest(_GearmanAbstractTest):
         single_request = self.generate_job_request()
 
         def retrieve_status_timeout(rx_conns, wr_conns, ex_conns):
-            pass
+            return rx_conns, wr_conns, ex_conns
 
         self.connection_manager.handle_connection_activity = retrieve_status_timeout
 


### PR DESCRIPTION
If a connection was dropped or encountered an exception, it would be closed, but remain in the submitted_connections used in the next iteration of the loop without being reconnected. Additionally, handle_connection_activity returns an updated list of read/write/excepted connections which the various checks should be using but were not. Both of these were minor issues that would only become visible in an environment with connection failures.

Aside:
The poll_connections_until_stopped loop continues until there are no available connected connections. This is most likely not ideal behavior, as if we have one connection that remains we will continue to only make requests to it, without trying to reestablish the other connections.
