### PR TITLE
Fixed handling of null chars in arguments. No 'ascii' checks.

### DIFF
--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -50,7 +50,7 @@ GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG = 32
 GEARMAN_COMMAND_SUBMIT_JOB_LOW = 33
 GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG = 34
 
-# Fake command code 
+# Fake command code
 GEARMAN_COMMAND_TEXT_COMMAND = 9999
 
 GEARMAN_PARAMS_FOR_COMMAND = {
@@ -242,6 +242,11 @@ def pack_binary_command(cmd_type, cmd_args, is_response=False):
         raise ProtocolError('Received non-binary arguments: %r' % cmd_args)
 
     data_items = [cmd_args[param] for param in expected_cmd_params]
+
+    # Now check that all but the last argument are free of \0 as per the protocol spec.
+    if compat.any('\0' in argument for argument in data_items[:-1]):
+        raise ProtocolError('Received arguments with NULL byte in non-final argument')
+
     binary_payload = NULL_CHAR.join(data_items)
 
     # Pack the header in the !4sII format then append the binary payload

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -133,6 +133,21 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         cmd_args = dict(job_handle=unicode(12345))
         self.assertRaises(ProtocolError, protocol.pack_binary_command, cmd_type, cmd_args)
 
+        # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
+        cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
+        cmd_args = dict(task='funct\x00ion', data='abcd', unique='12345')
+        self.assertRaises(ProtocolError, protocol.pack_binary_command, cmd_type, cmd_args)
+
+        # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
+        cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
+        cmd_args = dict(task='function', data='ab\x00cd', unique='12345')
+        protocol.pack_binary_command(cmd_type, cmd_args) # Should not raise, 'data' is last.
+
+        # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
+        cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
+        cmd_args = dict(task='function', data='abcd', unique='123\x0045')
+        self.assertRaises(ProtocolError, protocol.pack_binary_command, cmd_type, cmd_args)
+
     def test_packing_response(self):
         # Test packing a response for a job (server side packing)
         cmd_type = protocol.GEARMAN_COMMAND_NO_JOB


### PR DESCRIPTION
The protocol says;
"Arguments given in the data part are separated by a NULL byte, and
the last argument is determined by the size of data after the last
NULL byte separator. All job handle arguments must not be longer than
64 bytes, including NULL terminator."

This adds a check to ensure that all arguments, but the last, do
not contain \0.

I do not check the args pass encode('ascii'). It would make sense,
since it's not known what will happen inside the bowels of gearmand.
It uses memcmp for the most part, and we have to assume the
queue storage can handle utf8, as long as it does not contain
\0.
