### PR TITLE
Raise an exception if we didn't send everything

### DIFF
--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -207,8 +207,14 @@ class GearmanConnection(object):
 
         if bytes_sent == 0:
             self.throw_exception(message='remote disconnected')
+        
+        if bytes_sent < len(self._outgoing_buffer):
+            self.throw_exception(message='socket full, only sent %d of %d bytes' % (bytes_sent, len(self._outgoing_buffer)))
 
+        # if this doesn't clear out the buffer, we already raised an exception...
         self._outgoing_buffer = self._outgoing_buffer[bytes_sent:]
+        
+        # XXX: This should probably, based on most standards, return the length sent, not the length remaining
         return len(self._outgoing_buffer)
 
     def _pack_command(self, cmd_type, cmd_args):

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -208,6 +208,7 @@ class GearmanConnection(object):
         if bytes_sent == 0:
             self.throw_exception(message='remote disconnected')
         
+        # This is being done for debugging purposes.
         if bytes_sent < len(self._outgoing_buffer):
             self.throw_exception(message='socket full, only sent %d of %d bytes' % (bytes_sent, len(self._outgoing_buffer)))
 


### PR DESCRIPTION
This is mostly a test. If we reach a point where we didn't send everything, it is highly likely something went wrong. Previously, we would try to send the rest of the buffer on the next `handle_write` call, but instead we'll raise an exception. There are some notes to this affect in the added comments.
