### PR TITLE
Reconnect (if safe to do so) between calls to poll_connections_until_stopped

### DIFF
--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -189,6 +189,12 @@ class GearmanConnection(object):
 
         self._outgoing_buffer = ''.join(packed_data)
 
+    def reconnect(self):
+        """If we don't have outgoing data waiting, close the current connection and open a new one."""
+        if not self._outgoing_buffer:
+            self.close()
+            self.connect()
+
     def send_data_to_socket(self):
         """Send data from buffer -> socket
 

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -195,7 +195,7 @@ class GearmanConnection(object):
 
         self._outgoing_buffer = ''.join(packed_data)
 
-    def reconnect(self):
+    def maybe_reconnect(self):
         """If we don't have outgoing data waiting after a length of time, close the current connection and open a new one."""
         if self.connect_time < time.time() - self.reconnect_timeout:
             if not self._outgoing_buffer:

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -92,8 +92,7 @@ class GearmanConnectionManager(object):
         assert current_connection in self.connection_list, "Unknown connection - %r" % current_connection
 
         if current_connection.connected:
-            current_connection.close()
-            current_connection.connect()
+            current_connection.reconnect()
             return current_connection
 
         # !NOTE! May throw a ConnectionError

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -90,7 +90,10 @@ class GearmanConnectionManager(object):
         !NOTE! This function can throw a ConnectionError which deriving ConnectionManagers should catch
         """
         assert current_connection in self.connection_list, "Unknown connection - %r" % current_connection
+
         if current_connection.connected:
+            current_connection.close()
+            current_connection.connect()
             return current_connection
 
         # !NOTE! May throw a ConnectionError

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -92,7 +92,7 @@ class GearmanConnectionManager(object):
         assert current_connection in self.connection_list, "Unknown connection - %r" % current_connection
 
         if current_connection.connected:
-            current_connection.reconnect()
+            current_connection.maybe_reconnect()
             return current_connection
 
         # !NOTE! May throw a ConnectionError

--- a/tests/_core_testing.py
+++ b/tests/_core_testing.py
@@ -20,6 +20,8 @@ class MockGearmanConnection(GearmanConnection):
         self._fail_on_bind = False
         self._fail_on_read = False
         self._fail_on_write = False
+        self.connect_time = 0.0
+        self.reconnect_timeout = 0.0
 
     def _create_client_socket(self):
         if self._fail_on_bind:


### PR DESCRIPTION
This should safely reconnect the underlying system socket when `establish_connection` is called. It will only reconnect if the outgoing buffer is empty, which should prevent commands from being broken between connections. If this doesn't break anything itself, it should clear up issues with linger, unused connections by resetting them.
