### PR TITLE
Add support for SUBMIT_JOB_EPOCH

### DIFF
--- a/gearman/job.py
+++ b/gearman/job.py
@@ -3,27 +3,29 @@ from gearman.constants import PRIORITY_NONE, JOB_UNKNOWN, JOB_PENDING, JOB_CREAT
 
 class GearmanJob(object):
     """Represents the basics of a job... used in GearmanClient / GearmanWorker to represent job states"""
-    def __init__(self, connection, handle, task, unique, data):
+    def __init__(self, connection, handle, task, unique, data, when_to_run):
         self.connection = connection
         self.handle = handle
 
         self.task = task
         self.unique = unique
         self.data = data
+        self.when_to_run = when_to_run
 
     def to_dict(self):
-        return dict(task=self.task, job_handle=self.handle, unique=self.unique, data=self.data)
+        return dict(task=self.task, job_handle=self.handle, unique=self.unique, data=self.data, when_to_run=self.when_to_run)
 
     def __repr__(self):
-        return '<GearmanJob connection/handle=(%r, %r), task=%s, unique=%s, data=%r>' % (self.connection, self.handle, self.task, self.unique, self.data)
+        return '<GearmanJob connection/handle=(%r, %r), task=%s, unique=%s, data=%r, when_to_run=%d>' % (self.connection, self.handle, self.task, self.unique, self.data, self.when_to_run)
 
 class GearmanJobRequest(object):
     """Represents a job request... used in GearmanClient to represent job states"""
-    def __init__(self, gearman_job, initial_priority=PRIORITY_NONE, background=False, max_attempts=1):
+    def __init__(self, gearman_job, initial_priority=PRIORITY_NONE, background=False, run_later=False, max_attempts=1):
         self.gearman_job = gearman_job
 
         self.priority = initial_priority
         self.background = background
+        self.run_later = run_later
 
         self.connection_attempts = 0
         self.max_connection_attempts = max_attempts
@@ -79,5 +81,5 @@ class GearmanJobRequest(object):
         return actually_complete
 
     def __repr__(self):
-        formatted_representation = '<GearmanJobRequest task=%r, unique=%r, priority=%r, background=%r, state=%r, timed_out=%r>'
-        return formatted_representation % (self.job.task, self.job.unique, self.priority, self.background, self.state, self.timed_out)
+        formatted_representation = '<GearmanJobRequest task=%r, unique=%r, when_to_run=%r, priority=%r, background=%r, run_later=%r, state=%r, timed_out=%r>'
+        return formatted_representation % (self.job.task, self.job.unique, self.job.when_to_run, self.priority, self.background, self.run_later, self.state, self.timed_out)

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -50,6 +50,8 @@ GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG = 32
 GEARMAN_COMMAND_SUBMIT_JOB_LOW = 33
 GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG = 34
 
+GEARMAN_COMMAND_SUBMIT_JOB_EPOCH = 36
+
 # Fake command code
 GEARMAN_COMMAND_TEXT_COMMAND = 9999
 
@@ -94,6 +96,8 @@ GEARMAN_PARAMS_FOR_COMMAND = {
     GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG: ['task', 'unique', 'data'],
     GEARMAN_COMMAND_SUBMIT_JOB_LOW: ['task', 'unique', 'data'],
     GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG: ['task', 'unique', 'data'],
+
+    GEARMAN_COMMAND_SUBMIT_JOB_EPOCH: ['task', 'unique', 'when_to_run', 'data'],
 
     # Fake gearman command
     GEARMAN_COMMAND_TEXT_COMMAND: ['raw_text']
@@ -140,6 +144,8 @@ GEARMAN_COMMAND_TO_NAME = {
     GEARMAN_COMMAND_SUBMIT_JOB_LOW: 'GEARMAN_COMMAND_SUBMIT_JOB_LOW',
     GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG: 'GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG',
 
+    GEARMAN_COMMAND_SUBMIT_JOB_EPOCH: 'GEARMAN_COMMAND_SUBMIT_JOB_EPOCH',
+
     GEARMAN_COMMAND_TEXT_COMMAND: 'GEARMAN_COMMAND_TEXT_COMMAND'
 }
 
@@ -156,16 +162,17 @@ GEARMAN_SERVER_COMMAND_CANCEL_JOB = 'cancel job'
 def get_command_name(cmd_type):
     return GEARMAN_COMMAND_TO_NAME.get(cmd_type, cmd_type)
 
-def submit_cmd_for_background_priority(background, priority):
+def submit_cmd_for_background_priority_run_later(background, priority, run_later):
     cmd_type_lookup = {
-        (True, PRIORITY_NONE): GEARMAN_COMMAND_SUBMIT_JOB_BG,
-        (True, PRIORITY_LOW): GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG,
-        (True, PRIORITY_HIGH): GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG,
-        (False, PRIORITY_NONE): GEARMAN_COMMAND_SUBMIT_JOB,
-        (False, PRIORITY_LOW): GEARMAN_COMMAND_SUBMIT_JOB_LOW,
-        (False, PRIORITY_HIGH): GEARMAN_COMMAND_SUBMIT_JOB_HIGH
+        (True, PRIORITY_NONE, False): GEARMAN_COMMAND_SUBMIT_JOB_BG,
+        (True, PRIORITY_LOW, False): GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG,
+        (True, PRIORITY_HIGH, False): GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG,
+        (False, PRIORITY_NONE, False): GEARMAN_COMMAND_SUBMIT_JOB,
+        (False, PRIORITY_LOW, False): GEARMAN_COMMAND_SUBMIT_JOB_LOW,
+        (False, PRIORITY_HIGH, False): GEARMAN_COMMAND_SUBMIT_JOB_HIGH,
+        (True, PRIORITY_NONE, True): GEARMAN_COMMAND_SUBMIT_JOB_EPOCH
     }
-    lookup_tuple = (background, priority)
+    lookup_tuple = (background, priority, run_later)
     cmd_type = cmd_type_lookup[lookup_tuple]
     return cmd_type
 

--- a/gearman/worker.py
+++ b/gearman/worker.py
@@ -210,7 +210,7 @@ class GearmanWorker(GearmanConnectionManager):
     def create_job(self, command_handler, job_handle, task, unique, data):
         """Create a new job using our self.job_class"""
         current_connection = self.handler_to_connection_map[command_handler]
-        return self.job_class(current_connection, job_handle, task, unique, data)
+        return self.job_class(current_connection, job_handle, task, unique, data, None)
 
     def on_job_execute(self, current_job):
         try:
@@ -248,10 +248,10 @@ class GearmanWorker(GearmanConnectionManager):
             self.command_handler_holding_job_lock = None
 
         return True
-    
+
     def has_job_lock(self):
         return bool(self.command_handler_holding_job_lock is not None)
-    
+
     def check_job_lock(self, command_handler):
         """Check to see if we hold the job lock"""
         return bool(self.command_handler_holding_job_lock == command_handler)

--- a/tests/_core_testing.py
+++ b/tests/_core_testing.py
@@ -78,15 +78,15 @@ class _GearmanAbstractTest(unittest.TestCase):
         self.command_handler = self.connection_manager.connection_to_handler_map[self.connection]
 
     def generate_job(self):
-        return self.job_class(self.connection, handle=str(random.random()), task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        return self.job_class(self.connection, handle=str(random.random()), task='__test_ability__', unique=str(random.random()), data=str(random.random()), when_to_run=None)
 
     def generate_job_dict(self):
         current_job = self.generate_job()
         return current_job.to_dict()
 
-    def generate_job_request(self, priority=PRIORITY_NONE, background=False):
+    def generate_job_request(self, priority=PRIORITY_NONE, when_to_run=None, background=False):
         job_handle = str(random.random())
-        current_job = self.job_class(connection=self.connection, handle=job_handle, task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        current_job = self.job_class(connection=self.connection, handle=job_handle, task='__test_ability__', unique=str(random.random()), data=str(random.random()), when_to_run=when_to_run)
         current_request = self.job_request_class(current_job, initial_priority=priority, background=background)
 
         self.assertEqual(current_request.state, JOB_UNKNOWN)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -7,7 +7,7 @@ from gearman.client_handler import GearmanClientCommandHandler
 
 from gearman.constants import PRIORITY_NONE, PRIORITY_HIGH, PRIORITY_LOW, JOB_UNKNOWN, JOB_PENDING, JOB_CREATED, JOB_FAILED, JOB_COMPLETE
 from gearman.errors import ExceededConnectionAttempts, ServerUnavailable, InvalidClientState
-from gearman.protocol import submit_cmd_for_background_priority, GEARMAN_COMMAND_STATUS_RES, GEARMAN_COMMAND_GET_STATUS, GEARMAN_COMMAND_JOB_CREATED, \
+from gearman.protocol import submit_cmd_for_background_priority_run_later, GEARMAN_COMMAND_STATUS_RES, GEARMAN_COMMAND_GET_STATUS, GEARMAN_COMMAND_JOB_CREATED, \
     GEARMAN_COMMAND_WORK_STATUS, GEARMAN_COMMAND_WORK_FAIL, GEARMAN_COMMAND_WORK_COMPLETE, GEARMAN_COMMAND_WORK_DATA, GEARMAN_COMMAND_WORK_WARNING
 
 from tests._core_testing import _GearmanAbstractTest, MockGearmanConnectionManager, MockGearmanConnection
@@ -312,7 +312,7 @@ class ClientCommandHandlerInterfaceTest(_GearmanAbstractTest):
                 queued_request = self.command_handler.requests_awaiting_handles.popleft()
                 self.assertEqual(queued_request, current_request)
 
-                expected_cmd_type = submit_cmd_for_background_priority(background, priority)
+                expected_cmd_type = submit_cmd_for_background_priority_run_later(background, priority, False)
                 self.assert_sent_command(expected_cmd_type, task=gearman_job.task, data=gearman_job.data, unique=gearman_job.unique)
 
     def test_get_status_of_job(self):


### PR DESCRIPTION
- submit_job now accepts a 'when_to_run' parameter to take advantage of
  Gearman's ability to schedule jobs to be run in the future
