### PR TITLE
Retry gracefully when a server restarts

### DIFF
--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -69,7 +69,10 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
         if not self.requests_awaiting_handles:
             raise InvalidClientState('Received a job_handle with no pending requests')
 
-        # If our client got a JOB_CREATED, our request now has a server handle
+        """The gearman server returns JOB_CREATED responses in order
+        in response to SUBMIT_JOB_* requests.  We therefore know that the
+        handle we just got cooresponds to the first request awaiting a
+        handle"""
         current_request = self.requests_awaiting_handles.popleft()
         self._assert_request_state(current_request, JOB_PENDING)
 

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -201,9 +201,6 @@ class GearmanConnectionManager(object):
 
             any_activity = compat.any([read_connections, write_connections, dead_connections])
 
-            # Do not retry dead connections on the next iteration of the loop, as we closed them in handle_error
-            submitted_connections -= dead_connections
-
             callback_ok = callback_fxn(any_activity)
             connection_ok = compat.any(current_connection.connected for current_connection in submitted_connections)
 

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -132,7 +132,7 @@ class ClientTest(_GearmanAbstractTest):
         current_request.max_connection_attempts = self.connection_manager.expected_failures + 1
         current_request.state = JOB_UNKNOWN
 
-        accepted_jobs = self.connection_manager.wait_until_jobs_accepted([current_request])
+        self.connection_manager.wait_until_jobs_accepted([current_request])
         self.assertEquals(current_request.state, JOB_CREATED)
         self.assertEquals(current_request.connection_attempts, current_request.max_connection_attempts)
 
@@ -452,7 +452,6 @@ class ClientCommandHandlerStateMachineTest(_GearmanAbstractTest):
         current_request = self.generate_job_request()
 
         job_handle = current_request.job.handle
-        new_data = str(random.random())
         self.command_handler.recv_command(GEARMAN_COMMAND_WORK_FAIL, job_handle=job_handle)
 
         self.assertEqual(current_request.state, JOB_FAILED)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -1,5 +1,4 @@
 import collections
-from contextlib import nested
 import mock
 import random
 import unittest
@@ -167,9 +166,7 @@ class ClientTest(_GearmanAbstractTest):
                     job_handle=expected_job.handle)
                 return set([flaky_connection]), set(), set()
 
-        with nested(
-                mock.patch.object(self.connection_manager, 'poll_connections_once', poll_connections_once),
-            ):
+        with mock.patch.object(self.connection_manager, 'poll_connections_once', poll_connections_once):
             job_request = self.connection_manager.submit_job(expected_job.task, expected_job.data, unique=expected_job.unique, background=True, priority=PRIORITY_LOW, wait_until_complete=False, max_retries=1)
             self.assertEqual(job_request.state, JOB_CREATED)
 


### PR DESCRIPTION
Currently, python-gearman fails to correctly retry submitting jobs when a connection it holds to the gearmand 'flakes.'  A 'flake' of a gearmand is when the TCP connection is temporarily broken, but the gearmand is listening as of the next retry.  Commonly we see this when gearmand is restarted, as the previous TCP connection between client and server will no longer be open.

Currently, `poll_connections_until_stopped` will stop polling on a Connection object which has become disconnected.  This is a mistake, because the Connection object may become reconnected by virtue of `send_job_request`, which is called recursively by the callback function `continue_while_jobs_pending`.  In that case, the client should definitely be polling on that Connection object, because it is both connected and has valid data to send to the server.

I also added a comment on an unrelated function and fixed a few pyflakes issues that I saw.
