### PR TITLE
Require cert validation of server.

### DIFF
--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -107,6 +107,7 @@ class GearmanConnection(object):
                                                 keyfile=self.keyfile,
                                                 certfile=self.certfile,
                                                 ca_certs=self.ca_certs,
+                                                cert_reqs=ssl.CERT_REQUIRED,
                                                 ssl_version=ssl.PROTOCOL_TLSv1)
 
             client_socket.connect((self.gearman_host, self.gearman_port))


### PR DESCRIPTION
Without this option, a cert wasn't being required from the server. That seems like a logical thing to require, so let's do that.
