### PR TITLE
Handle read deadlocks

### DIFF
--- a/gearman/__init__.py
+++ b/gearman/__init__.py
@@ -2,7 +2,7 @@
 Gearman API - Client, worker, and admin client interfaces
 """
 
-__version__ = '2.1.0-lctv'
+__version__ = '2.0.2'
 
 from gearman.admin_client import GearmanAdminClient
 from gearman.client import GearmanClient

--- a/gearman/__init__.py
+++ b/gearman/__init__.py
@@ -2,7 +2,7 @@
 Gearman API - Client, worker, and admin client interfaces
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.2-lctv'
 
 from gearman.admin_client import GearmanAdminClient
 from gearman.client import GearmanClient

--- a/gearman/__init__.py
+++ b/gearman/__init__.py
@@ -2,7 +2,7 @@
 Gearman API - Client, worker, and admin client interfaces
 """
 
-__version__ = '2.0.2'
+__version__ = '2.1.0-lctv'
 
 from gearman.admin_client import GearmanAdminClient
 from gearman.client import GearmanClient

--- a/gearman/admin_client.py
+++ b/gearman/admin_client.py
@@ -90,16 +90,10 @@ class GearmanAdminClient(GearmanConnectionManager):
 
     def wait_until_server_responds(self, expected_type):
         current_handler = self.current_handler
-        stopwatch = util.Stopwatch(self.poll_timeout)
-        time_remaining = stopwatch.get_time_remaining()
-
         def continue_while_no_response(any_activity):
             return (not current_handler.response_ready)
 
-        while time_remaining > 0.0 and not self.current_handler.response_ready:
-            self.poll_connections_until_stopped([self.current_connection], continue_while_no_response, timeout=time_remaining)
-            time_remaining = stopwatch.get_time_remaining()
-
+        self.poll_connections_until_stopped([self.current_connection], continue_while_no_response, timeout=self.poll_timeout)
         if not self.current_handler.response_ready:
             raise InvalidAdminClientState('Admin client timed out after %f second(s)' % self.poll_timeout)
 

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -129,7 +129,7 @@ class GearmanConnectionManager(object):
         # a timeout of -1 when used with epoll will block until there
         # is activity. Select does not support negative timeouts, so this
         # is translated to a timeout=None when falling back to select
-        timeout = timeout or -1 
+        timeout = timeout or -1
 
         readable = set()
         writable = set()
@@ -191,14 +191,15 @@ class GearmanConnectionManager(object):
         connection_ok = compat.any(current_connection.connected for current_connection in submitted_connections)
         poller = gearman.io.get_connection_poller()
         if connection_ok:
-            self._register_connections_with_poller(submitted_connections, 
+            self._register_connections_with_poller(submitted_connections,
                     poller)
             connection_map = dict([(c.fileno(), c) for c in
                 submitted_connections if c.connected])
 
         while connection_ok and callback_ok:
             time_remaining = stopwatch.get_time_remaining()
-            if time_remaining == 0.0:
+            callback_ok = callback_fxn(any_activity)
+            if time_remaining == 0.0 or (any_activity and not callback_ok):
                 break
 
             # Do a single robust select and handle all connection activity

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -129,7 +129,7 @@ class GearmanConnectionManager(object):
         # a timeout of -1 when used with epoll will block until there
         # is activity. Select does not support negative timeouts, so this
         # is translated to a timeout=None when falling back to select
-        timeout = timeout or -1
+        timeout = timeout or -1 
 
         readable = set()
         writable = set()
@@ -191,15 +191,14 @@ class GearmanConnectionManager(object):
         connection_ok = compat.any(current_connection.connected for current_connection in submitted_connections)
         poller = gearman.io.get_connection_poller()
         if connection_ok:
-            self._register_connections_with_poller(submitted_connections,
+            self._register_connections_with_poller(submitted_connections, 
                     poller)
             connection_map = dict([(c.fileno(), c) for c in
                 submitted_connections if c.connected])
 
         while connection_ok and callback_ok:
             time_remaining = stopwatch.get_time_remaining()
-            callback_ok = callback_fxn(any_activity)
-            if time_remaining == 0.0 or (any_activity and not callback_ok):
+            if time_remaining == 0.0:
                 break
 
             # Do a single robust select and handle all connection activity

--- a/gearman/job.py
+++ b/gearman/job.py
@@ -3,27 +3,29 @@ from gearman.constants import PRIORITY_NONE, JOB_UNKNOWN, JOB_PENDING, JOB_CREAT
 
 class GearmanJob(object):
     """Represents the basics of a job... used in GearmanClient / GearmanWorker to represent job states"""
-    def __init__(self, connection, handle, task, unique, data):
+    def __init__(self, connection, handle, task, unique, data, when_to_run):
         self.connection = connection
         self.handle = handle
 
         self.task = task
         self.unique = unique
         self.data = data
+        self.when_to_run = when_to_run
 
     def to_dict(self):
-        return dict(task=self.task, job_handle=self.handle, unique=self.unique, data=self.data)
+        return dict(task=self.task, job_handle=self.handle, unique=self.unique, data=self.data, when_to_run=self.when_to_run)
 
     def __repr__(self):
-        return '<GearmanJob connection/handle=(%r, %r), task=%s, unique=%s, data=%r>' % (self.connection, self.handle, self.task, self.unique, self.data)
+        return '<GearmanJob connection/handle=(%r, %r), task=%s, unique=%s, data=%r, when_to_run=%d>' % (self.connection, self.handle, self.task, self.unique, self.data, self.when_to_run)
 
 class GearmanJobRequest(object):
     """Represents a job request... used in GearmanClient to represent job states"""
-    def __init__(self, gearman_job, initial_priority=PRIORITY_NONE, background=False, max_attempts=1):
+    def __init__(self, gearman_job, initial_priority=PRIORITY_NONE, background=False, run_later=False, max_attempts=1):
         self.gearman_job = gearman_job
 
         self.priority = initial_priority
         self.background = background
+        self.run_later = run_later
 
         self.connection_attempts = 0
         self.max_connection_attempts = max_attempts
@@ -79,5 +81,5 @@ class GearmanJobRequest(object):
         return actually_complete
 
     def __repr__(self):
-        formatted_representation = '<GearmanJobRequest task=%r, unique=%r, priority=%r, background=%r, state=%r, timed_out=%r>'
-        return formatted_representation % (self.job.task, self.job.unique, self.priority, self.background, self.state, self.timed_out)
+        formatted_representation = '<GearmanJobRequest task=%r, unique=%r, when_to_run=%r, priority=%r, background=%r, run_later=%r, state=%r, timed_out=%r>'
+        return formatted_representation % (self.job.task, self.job.unique, self.job.when_to_run, self.priority, self.background, self.run_later, self.state, self.timed_out)

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -50,6 +50,8 @@ GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG = 32
 GEARMAN_COMMAND_SUBMIT_JOB_LOW = 33
 GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG = 34
 
+GEARMAN_COMMAND_SUBMIT_JOB_EPOCH = 36
+
 # Fake command code
 GEARMAN_COMMAND_TEXT_COMMAND = 9999
 
@@ -94,6 +96,8 @@ GEARMAN_PARAMS_FOR_COMMAND = {
     GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG: ['task', 'unique', 'data'],
     GEARMAN_COMMAND_SUBMIT_JOB_LOW: ['task', 'unique', 'data'],
     GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG: ['task', 'unique', 'data'],
+
+    GEARMAN_COMMAND_SUBMIT_JOB_EPOCH: ['task', 'unique', 'when_to_run', 'data'],
 
     # Fake gearman command
     GEARMAN_COMMAND_TEXT_COMMAND: ['raw_text']
@@ -140,6 +144,8 @@ GEARMAN_COMMAND_TO_NAME = {
     GEARMAN_COMMAND_SUBMIT_JOB_LOW: 'GEARMAN_COMMAND_SUBMIT_JOB_LOW',
     GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG: 'GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG',
 
+    GEARMAN_COMMAND_SUBMIT_JOB_EPOCH: 'GEARMAN_COMMAND_SUBMIT_JOB_EPOCH',
+
     GEARMAN_COMMAND_TEXT_COMMAND: 'GEARMAN_COMMAND_TEXT_COMMAND'
 }
 
@@ -152,16 +158,17 @@ GEARMAN_SERVER_COMMAND_SHUTDOWN = 'shutdown'
 def get_command_name(cmd_type):
     return GEARMAN_COMMAND_TO_NAME.get(cmd_type, cmd_type)
 
-def submit_cmd_for_background_priority(background, priority):
+def submit_cmd_for_background_priority_run_later(background, priority, run_later):
     cmd_type_lookup = {
-        (True, PRIORITY_NONE): GEARMAN_COMMAND_SUBMIT_JOB_BG,
-        (True, PRIORITY_LOW): GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG,
-        (True, PRIORITY_HIGH): GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG,
-        (False, PRIORITY_NONE): GEARMAN_COMMAND_SUBMIT_JOB,
-        (False, PRIORITY_LOW): GEARMAN_COMMAND_SUBMIT_JOB_LOW,
-        (False, PRIORITY_HIGH): GEARMAN_COMMAND_SUBMIT_JOB_HIGH
+        (True, PRIORITY_NONE, False): GEARMAN_COMMAND_SUBMIT_JOB_BG,
+        (True, PRIORITY_LOW, False): GEARMAN_COMMAND_SUBMIT_JOB_LOW_BG,
+        (True, PRIORITY_HIGH, False): GEARMAN_COMMAND_SUBMIT_JOB_HIGH_BG,
+        (False, PRIORITY_NONE, False): GEARMAN_COMMAND_SUBMIT_JOB,
+        (False, PRIORITY_LOW, False): GEARMAN_COMMAND_SUBMIT_JOB_LOW,
+        (False, PRIORITY_HIGH, False): GEARMAN_COMMAND_SUBMIT_JOB_HIGH,
+        (True, PRIORITY_NONE, True): GEARMAN_COMMAND_SUBMIT_JOB_EPOCH
     }
-    lookup_tuple = (background, priority)
+    lookup_tuple = (background, priority, run_later)
     cmd_type = cmd_type_lookup[lookup_tuple]
     return cmd_type
 

--- a/gearman/worker.py
+++ b/gearman/worker.py
@@ -210,7 +210,7 @@ class GearmanWorker(GearmanConnectionManager):
     def create_job(self, command_handler, job_handle, task, unique, data):
         """Create a new job using our self.job_class"""
         current_connection = self.handler_to_connection_map[command_handler]
-        return self.job_class(current_connection, job_handle, task, unique, data)
+        return self.job_class(current_connection, job_handle, task, unique, data, None)
 
     def on_job_execute(self, current_job):
         try:
@@ -248,10 +248,10 @@ class GearmanWorker(GearmanConnectionManager):
             self.command_handler_holding_job_lock = None
 
         return True
-    
+
     def has_job_lock(self):
         return bool(self.command_handler_holding_job_lock is not None)
-    
+
     def check_job_lock(self, command_handler):
         """Check to see if we hold the job lock"""
         return bool(self.command_handler_holding_job_lock == command_handler)

--- a/tests/_core_testing.py
+++ b/tests/_core_testing.py
@@ -78,15 +78,15 @@ class _GearmanAbstractTest(unittest.TestCase):
         self.command_handler = self.connection_manager.connection_to_handler_map[self.connection]
 
     def generate_job(self):
-        return self.job_class(self.connection, handle=str(random.random()), task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        return self.job_class(self.connection, handle=str(random.random()), task='__test_ability__', unique=str(random.random()), data=str(random.random()), when_to_run=None)
 
     def generate_job_dict(self):
         current_job = self.generate_job()
         return current_job.to_dict()
 
-    def generate_job_request(self, priority=PRIORITY_NONE, background=False):
+    def generate_job_request(self, priority=PRIORITY_NONE, when_to_run=None, background=False):
         job_handle = str(random.random())
-        current_job = self.job_class(connection=self.connection, handle=job_handle, task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        current_job = self.job_class(connection=self.connection, handle=job_handle, task='__test_ability__', unique=str(random.random()), data=str(random.random()), when_to_run=when_to_run)
         current_request = self.job_request_class(current_job, initial_priority=priority, background=background)
 
         self.assertEqual(current_request.state, JOB_UNKNOWN)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -7,7 +7,7 @@ from gearman.client_handler import GearmanClientCommandHandler
 
 from gearman.constants import PRIORITY_NONE, PRIORITY_HIGH, PRIORITY_LOW, JOB_UNKNOWN, JOB_PENDING, JOB_CREATED, JOB_FAILED, JOB_COMPLETE
 from gearman.errors import ExceededConnectionAttempts, ServerUnavailable, InvalidClientState
-from gearman.protocol import submit_cmd_for_background_priority, GEARMAN_COMMAND_STATUS_RES, GEARMAN_COMMAND_GET_STATUS, GEARMAN_COMMAND_JOB_CREATED, \
+from gearman.protocol import submit_cmd_for_background_priority_run_later, GEARMAN_COMMAND_STATUS_RES, GEARMAN_COMMAND_GET_STATUS, GEARMAN_COMMAND_JOB_CREATED, \
     GEARMAN_COMMAND_WORK_STATUS, GEARMAN_COMMAND_WORK_FAIL, GEARMAN_COMMAND_WORK_COMPLETE, GEARMAN_COMMAND_WORK_DATA, GEARMAN_COMMAND_WORK_WARNING
 
 from tests._core_testing import _GearmanAbstractTest, MockGearmanConnectionManager, MockGearmanConnection
@@ -312,7 +312,7 @@ class ClientCommandHandlerInterfaceTest(_GearmanAbstractTest):
                 queued_request = self.command_handler.requests_awaiting_handles.popleft()
                 self.assertEqual(queued_request, current_request)
 
-                expected_cmd_type = submit_cmd_for_background_priority(background, priority)
+                expected_cmd_type = submit_cmd_for_background_priority_run_later(background, priority, False)
                 self.assert_sent_command(expected_cmd_type, task=gearman_job.task, data=gearman_job.data, unique=gearman_job.unique)
 
     def test_get_status_of_job(self):


### PR DESCRIPTION
Updated to latest upstream, reverted our last bug fix that is now unnecessary and add some handling for deadlocks when server and worker are both trying to read
