### PR TITLE
Don't remove entries from handle_to_request_map.

### DIFF
--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -54,10 +54,6 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
     def _register_request(self, current_request):
         self.handle_to_request_map[current_request.job.handle] = current_request
 
-    def _unregister_request(self, current_request):
-        # De-allocate this request for all jobs
-        return self.handle_to_request_map.pop(current_request.job.handle, None)
-
     ##################################################################
     ## Gearman command callbacks with kwargs defined by protocol.py ##
     ##################################################################
@@ -122,7 +118,6 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
 
         current_request.result = self.decode_data(data)
         current_request.state = JOB_COMPLETE
-        self._unregister_request(current_request)
 
         return True
 
@@ -132,7 +127,6 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
         self._assert_request_state(current_request, JOB_CREATED)
 
         current_request.state = JOB_FAILED
-        self._unregister_request(current_request)
 
         return True
 
@@ -161,9 +155,5 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
             'denominator': int(denominator),
             'time_received': time.time()
         }
-
-        # If the server doesn't know about this request, we no longer need to track it
-        if not job_known:
-            self._unregister_request(current_request)
 
         return True


### PR DESCRIPTION
Since it's a WeakValueDict, no memory leak will be caused by not
removing entries, and in some cases entries are used even after
COMPLETE messages.

Fixes https://github.com/Yelp/python-gearman/issues/13
