### PR TITLE
Various changes towards making codebase compatible with 2.x and 3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,10 @@ dist
 build
 *.swo
 
+# Packaging
+*.egg-info/*
+
 # Testing
 .tox
+.coverage
+htmlcov/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ MANIFEST
 dist
 build
 *.swo
+
+# Testing
+.tox

--- a/gearman/admin_client.py
+++ b/gearman/admin_client.py
@@ -13,7 +13,7 @@ from gearman.protocol import GEARMAN_COMMAND_ECHO_RES, GEARMAN_COMMAND_ECHO_REQ,
 
 gearman_logger = logging.getLogger(__name__)
 
-ECHO_STRING = "ping? pong!"
+ECHO_STRING = b"ping? pong!"
 DEFAULT_ADMIN_CLIENT_TIMEOUT = 10.0
 
 class GearmanAdminClient(GearmanConnectionManager):

--- a/gearman/admin_client_handler.py
+++ b/gearman/admin_client_handler.py
@@ -100,14 +100,14 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server status message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == b'.':
+        if raw_text == '.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split(b'\t')
+        split_tokens = raw_text.split('\t')
         if len(split_tokens) != self.STATUS_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.STATUS_FIELDS, split_tokens))
 
@@ -131,17 +131,17 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server workers message line by line"""
         # If we received a '.', we've finished parsing this workers message
         # Pack up our output and reset our response queue
-        if raw_text == b'.':
+        if raw_text == '.':
             output_response = tuple(self._workers_response)
             self._recv_responses.append(output_response)
             self._workers_response = []
             return False
 
-        split_tokens = raw_text.split(b' ')
+        split_tokens = raw_text.split(' ')
         if len(split_tokens) < self.WORKERS_FIELDS:
             raise ProtocolError('Received %d tokens, expected >= 4 tokens: %r' % (len(split_tokens), split_tokens))
 
-        if split_tokens[3] != b':':
+        if split_tokens[3] != ':':
             raise ProtocolError('Malformed worker response: %r' % (split_tokens, ))
 
         # Label our fields and make the results Python friendly
@@ -155,8 +155,8 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
 
     def recv_server_maxqueue(self, raw_text):
         """Maxqueue response is a simple passthrough"""
-        if raw_text != b'OK':
-            raise ProtocolError("Expected 'OK', received: %s" % raw_text.decode('ascii'))
+        if raw_text != 'OK':
+            raise ProtocolError("Expected 'OK', received: %s" % raw_text)
 
         self._recv_responses.append(raw_text)
         return False

--- a/gearman/admin_client_handler.py
+++ b/gearman/admin_client_handler.py
@@ -175,14 +175,14 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a show jobs message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == b'.':
+        if raw_text == '.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split(b'\t')
+        split_tokens = raw_text.split('\t')
         if len(split_tokens) != self.JOB_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.JOB_FIELDS, split_tokens))
 

--- a/gearman/admin_client_handler.py
+++ b/gearman/admin_client_handler.py
@@ -206,19 +206,19 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server show unique jobs message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == b'.':
+        if raw_text == '.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split(b'\t')
+        split_tokens = raw_text.split('\t')
         if len(split_tokens) != self.UNIQUE_JOB_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.UNIQUE_JOB_FIELDS, split_tokens))
 
         # Label our fields and make the results Python friendly
-        unique = split_tokens
+        unique = split_tokens[0]
 
         job_dict = {}
         job_dict['unique'] = unique

--- a/gearman/admin_client_handler.py
+++ b/gearman/admin_client_handler.py
@@ -100,14 +100,14 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server status message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == '.':
+        if raw_text == b'.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split('\t')
+        split_tokens = raw_text.split(b'\t')
         if len(split_tokens) != self.STATUS_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.STATUS_FIELDS, split_tokens))
 
@@ -131,17 +131,17 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server workers message line by line"""
         # If we received a '.', we've finished parsing this workers message
         # Pack up our output and reset our response queue
-        if raw_text == '.':
+        if raw_text == b'.':
             output_response = tuple(self._workers_response)
             self._recv_responses.append(output_response)
             self._workers_response = []
             return False
 
-        split_tokens = raw_text.split(' ')
+        split_tokens = raw_text.split(b' ')
         if len(split_tokens) < self.WORKERS_FIELDS:
             raise ProtocolError('Received %d tokens, expected >= 4 tokens: %r' % (len(split_tokens), split_tokens))
 
-        if split_tokens[3] != ':':
+        if split_tokens[3] != b':':
             raise ProtocolError('Malformed worker response: %r' % (split_tokens, ))
 
         # Label our fields and make the results Python friendly
@@ -155,8 +155,8 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
 
     def recv_server_maxqueue(self, raw_text):
         """Maxqueue response is a simple passthrough"""
-        if raw_text != 'OK':
-            raise ProtocolError("Expected 'OK', received: %s" % raw_text)
+        if raw_text != b'OK':
+            raise ProtocolError("Expected 'OK', received: %s" % raw_text.decode('ascii'))
 
         self._recv_responses.append(raw_text)
         return False
@@ -175,14 +175,14 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a show jobs message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == '.':
+        if raw_text == b'.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split('\t')
+        split_tokens = raw_text.split(b'\t')
         if len(split_tokens) != self.JOB_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.JOB_FIELDS, split_tokens))
 
@@ -206,14 +206,14 @@ class GearmanAdminClientCommandHandler(GearmanCommandHandler):
         """Slowly assemble a server show unique jobs message line by line"""
         # If we received a '.', we've finished parsing this status message
         # Pack up our output and reset our response queue
-        if raw_text == '.':
+        if raw_text == b'.':
             output_response = tuple(self._status_response)
             self._recv_responses.append(output_response)
             self._status_response = []
             return False
 
         # If we didn't get a final response, split our line and interpret all the data
-        split_tokens = raw_text.split('\t')
+        split_tokens = raw_text.split(b'\t')
         if len(split_tokens) != self.UNIQUE_JOB_FIELDS:
             raise ProtocolError('Received %d tokens, expected %d tokens: %r' % (len(split_tokens), self.UNIQUE_JOB_FIELDS, split_tokens))
 

--- a/gearman/client.py
+++ b/gearman/client.py
@@ -1,3 +1,4 @@
+import codecs
 import collections
 from gearman import compat
 import logging
@@ -169,7 +170,7 @@ class GearmanClient(GearmanConnectionManager):
         # Make sure we have a unique identifier for ALL our tasks
         job_unique = job_info.get('unique')
         if not job_unique:
-            job_unique = os.urandom(self.random_unique_bytes).encode('hex')
+            job_unique = codecs.encode(os.urandom(self.random_unique_bytes), 'hex_codec')
 
         current_job = self.job_class(connection=None, handle=None, task=job_info['task'], unique=job_unique, data=job_info['data'])
 

--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -48,7 +48,7 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
         for pending_request in self.requests_awaiting_handles:
             pending_request.state = JOB_UNKNOWN
 
-        for inflight_request in self.handle_to_request_map.itervalues():
+        for inflight_request in self.handle_to_request_map.values():
             inflight_request.state = JOB_UNKNOWN
 
     def _register_request(self, current_request):

--- a/gearman/compat.py
+++ b/gearman/compat.py
@@ -1,6 +1,14 @@
 """
 Gearman compatibility module
 """
+import sys
+
+PY3 = sys.version_info[0] >= 3
+
+if PY3:
+    bytes_type = bytes
+else:
+    bytes_type = str
 
 # Required for python2.4 backward compatibilty
 # Add a module attribute called "any" which is equivalent to "any"

--- a/gearman/compat.py
+++ b/gearman/compat.py
@@ -8,9 +8,11 @@ PY3 = sys.version_info[0] >= 3
 if PY3:
     basestring_type = str
     bytes_type = bytes
+    text_type = str
 else:
     basestring_type = basestring
     bytes_type = str
+    text_type = unicode
 
 # Required for python2.4 backward compatibilty
 # Add a module attribute called "any" which is equivalent to "any"

--- a/gearman/compat.py
+++ b/gearman/compat.py
@@ -6,8 +6,10 @@ import sys
 PY3 = sys.version_info[0] >= 3
 
 if PY3:
+    basestring_type = str
     bytes_type = bytes
 else:
+    basestring_type = basestring
     bytes_type = str
 
 # Required for python2.4 backward compatibilty

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -115,7 +115,7 @@ class GearmanConnection(object):
                                                 ssl_version=ssl.PROTOCOL_TLSv1)
 
             client_socket.connect((self.gearman_host, self.gearman_port))
-        except socket.error, socket_exception:
+        except socket.error as socket_exception:
             self.throw_exception(exception=socket_exception)
 
         self.set_socket(client_socket)
@@ -172,7 +172,7 @@ class GearmanConnection(object):
                     continue
                 else:
                     self.throw_exception(exception=e)
-            except socket.error, socket_exception:
+            except socket.error as socket_exception:
                 self.throw_exception(exception=socket_exception)
 
             if len(recv_buffer) == 0:
@@ -247,7 +247,7 @@ class GearmanConnection(object):
                     continue
                 else:
                     self.throw_exception(exception=e)
-            except socket.error, socket_exception:
+            except socket.error as socket_exception:
                 self.throw_exception(exception=socket_exception)
 
             if bytes_sent == 0:

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -56,7 +56,7 @@ class GearmanConnection(object):
         self._is_server_side = None
 
         # Reset all our raw data buffers
-        self._incoming_buffer = array.array('c')
+        self._incoming_buffer = array.array('b')
         self._outgoing_buffer = ''
 
         # Toss all commands we may have sent or received

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -198,7 +198,7 @@ class GearmanConnection(object):
             cmd_type = None
             cmd_args = None
             cmd_len = 0
-        elif given_buffer[0] == NULL_CHAR:
+        elif given_buffer[0] == NULL_CHAR[0]:
             # We'll be expecting a response if we know we're a client side command
             is_response = bool(self._is_client_side)
             cmd_type, cmd_args, cmd_len = parse_binary_command(given_buffer, is_response=is_response)

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -9,7 +9,7 @@ import time
 from gearman import compat
 from gearman.errors import ConnectionError, ProtocolError, ServerUnavailable
 from gearman.constants import DEFAULT_GEARMAN_PORT, _DEBUG_MODE_
-from gearman.protocol import GEARMAN_PARAMS_FOR_COMMAND, GEARMAN_COMMAND_TEXT_COMMAND, NULL_CHAR, \
+from gearman.protocol import GEARMAN_PARAMS_FOR_COMMAND, GEARMAN_COMMAND_TEXT_COMMAND, NULL_BYTE, \
     get_command_name, pack_binary_command, parse_binary_command, parse_text_command, pack_text_command
 
 gearman_logger = logging.getLogger(__name__)
@@ -198,7 +198,7 @@ class GearmanConnection(object):
             cmd_type = None
             cmd_args = None
             cmd_len = 0
-        elif given_buffer[0] == NULL_CHAR[0]:
+        elif given_buffer[0] == NULL_BYTE[0]:
             # We'll be expecting a response if we know we're a client side command
             is_response = bool(self._is_client_side)
             cmd_type, cmd_args, cmd_len = parse_binary_command(given_buffer, is_response=is_response)

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -57,7 +57,7 @@ class GearmanConnection(object):
 
         # Reset all our raw data buffers
         self._incoming_buffer = array.array('b')
-        self._outgoing_buffer = ''
+        self._outgoing_buffer = b''
 
         # Toss all commands we may have sent or received
         self._incoming_commands = collections.deque()
@@ -224,7 +224,7 @@ class GearmanConnection(object):
             packed_command = self._pack_command(cmd_type, cmd_args)
             packed_data.append(packed_command)
 
-        self._outgoing_buffer = ''.join(packed_data)
+        self._outgoing_buffer = b''.join(packed_data)
 
     def send_data_to_socket(self):
         """Send data from buffer -> socket

--- a/gearman/connection.py
+++ b/gearman/connection.py
@@ -6,6 +6,7 @@ import ssl
 import struct
 import time
 
+from gearman import compat
 from gearman.errors import ConnectionError, ProtocolError, ServerUnavailable
 from gearman.constants import DEFAULT_GEARMAN_PORT, _DEBUG_MODE_
 from gearman.protocol import GEARMAN_PARAMS_FOR_COMMAND, GEARMAN_COMMAND_TEXT_COMMAND, NULL_CHAR, \
@@ -40,7 +41,7 @@ class GearmanConnection(object):
 
         # All 3 files must be given before SSL can be used
         self.use_ssl = False
-        if all([self.keyfile, self.certfile, self.ca_certs]):
+        if compat.all([self.keyfile, self.certfile, self.ca_certs]):
             self.use_ssl = True
 
         self._reset_connection()

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -64,7 +64,7 @@ class GearmanConnectionManager(object):
             if isinstance(element, compat.basestring_type):
                 self.add_connection(element)
             elif isinstance(element, dict):
-                if not all (k in element for k in ('host', 'port', 'keyfile', 'certfile', 'ca_certs')):
+                if not compat.all(k in element for k in ('host', 'port', 'keyfile', 'certfile', 'ca_certs')):
                     raise GearmanError("Incomplete SSL connection definition")
                 self.add_ssl_connection(element['host'], element['port'],
                                         element['keyfile'], element['certfile'],

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -61,7 +61,7 @@ class GearmanConnectionManager(object):
         host_list = host_list or []
         for element in host_list:
             # old style host:port pair
-            if isinstance(element, str):
+            if isinstance(element, compat.basestring_type):
                 self.add_connection(element)
             elif isinstance(element, dict):
                 if not all (k in element for k in ('host', 'port', 'keyfile', 'certfile', 'ca_certs')):

--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -23,7 +23,7 @@ class NoopEncoder(DataEncoder):
     """Provide common object dumps for all communications over gearman"""
     @classmethod
     def _enforce_byte_string(cls, given_object):
-        if type(given_object) != str:
+        if type(given_object) != compat.bytes_type:
             raise TypeError("Expecting byte string, got %r" % type(given_object))
 
     @classmethod

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -243,7 +243,7 @@ def pack_binary_command(cmd_type, cmd_args, is_response=False):
 
     # !NOTE! str should be replaced with bytes in Python 3.x
     # We will iterate in ORDER and str all our command arguments
-    if compat.any(type(param_value) != str for param_value in cmd_args.itervalues()):
+    if compat.any(type(param_value) != str for param_value in cmd_args.values()):
         raise ProtocolError('Received non-binary arguments: %r' % cmd_args)
 
     data_items = [cmd_args[param] for param in expected_cmd_params]

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -293,4 +293,4 @@ def pack_text_command(cmd_type, cmd_args):
     if cmd_line is None:
         raise ProtocolError('Did not receive arguments any valid arguments: %s' % cmd_args)
 
-    return str(cmd_line)
+    return compat.bytes_type(cmd_line)

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -293,4 +293,6 @@ def pack_text_command(cmd_type, cmd_args):
     if cmd_line is None:
         raise ProtocolError('Did not receive arguments any valid arguments: %s' % cmd_args)
 
+    if isinstance(cmd_line, compat.bytes_type):
+        return cmd_line
     return cmd_line.encode('ascii')

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -3,9 +3,9 @@ from gearman.constants import PRIORITY_NONE, PRIORITY_LOW, PRIORITY_HIGH
 from gearman.errors import ProtocolError
 from gearman import compat
 # Protocol specific constants
-NULL_CHAR = '\x00'
-MAGIC_RES_STRING = '%sRES' % NULL_CHAR
-MAGIC_REQ_STRING = '%sREQ' % NULL_CHAR
+NULL_CHAR = b'\x00'
+MAGIC_RES_STRING = NULL_CHAR + b'RES'
+MAGIC_REQ_STRING = NULL_CHAR + b'REQ'
 
 COMMAND_HEADER_SIZE = 12
 
@@ -207,7 +207,10 @@ def parse_binary_command(in_buffer, is_response=True):
     split_arguments = []
 
     if len(expected_cmd_params) > 0:
-        binary_payload = binary_payload.tostring()
+        if hasattr(binary_payload, 'tobytes'):
+            binary_payload = binary_payload.tobytes()
+        else:
+            binary_payload = binary_payload.tostring()
         split_arguments = binary_payload.split(NULL_CHAR, len(expected_cmd_params) - 1)
     elif binary_payload:
         raise ProtocolError('Expected no binary payload: %s' % get_command_name(cmd_type))
@@ -241,15 +244,14 @@ def pack_binary_command(cmd_type, cmd_args, is_response=False):
     else:
         magic = MAGIC_REQ_STRING
 
-    # !NOTE! str should be replaced with bytes in Python 3.x
-    # We will iterate in ORDER and str all our command arguments
-    if compat.any(type(param_value) != str for param_value in cmd_args.values()):
+    # We will iterate in ORDER and check all our command arguments are bytes
+    if compat.any(type(param_value) != compat.bytes_type for param_value in cmd_args.values()):
         raise ProtocolError('Received non-binary arguments: %r' % cmd_args)
 
     data_items = [cmd_args[param] for param in expected_cmd_params]
 
     # Now check that all but the last argument are free of \0 as per the protocol spec.
-    if compat.any('\0' in argument for argument in data_items[:-1]):
+    if compat.any(b'\0' in argument for argument in data_items[:-1]):
         raise ProtocolError('Received arguments with NULL byte in non-final argument')
 
     binary_payload = NULL_CHAR.join(data_items)
@@ -264,10 +266,14 @@ def parse_text_command(in_buffer):
     cmd_type = None
     cmd_args = None
     cmd_len = 0
-    if '\n' not in in_buffer:
+    if ord(b'\n') not in in_buffer:
         return cmd_type, cmd_args, cmd_len
 
-    text_command, in_buffer = in_buffer.tostring().split('\n', 1)
+    if hasattr(in_buffer, 'tobytes'):
+        text_command, in_buffer = in_buffer.tobytes().split(b'\n', 1)
+    else:
+        text_command, in_buffer = in_buffer.tostring().split(b'\n', 1)
+
     if NULL_CHAR in text_command:
         raise ProtocolError('Received unexpected character: %s' % text_command)
 

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -293,4 +293,4 @@ def pack_text_command(cmd_type, cmd_args):
     if cmd_line is None:
         raise ProtocolError('Did not receive arguments any valid arguments: %s' % cmd_args)
 
-    return cmd_line
+    return cmd_line.encode('ascii')

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -3,9 +3,9 @@ from gearman.constants import PRIORITY_NONE, PRIORITY_LOW, PRIORITY_HIGH
 from gearman.errors import ProtocolError
 from gearman import compat
 # Protocol specific constants
-NULL_CHAR = b'\x00'
-MAGIC_RES_STRING = NULL_CHAR + b'RES'
-MAGIC_REQ_STRING = NULL_CHAR + b'REQ'
+NULL_BYTE = b'\x00'
+MAGIC_RES_STRING = NULL_BYTE + b'RES'
+MAGIC_REQ_STRING = NULL_BYTE + b'REQ'
 
 COMMAND_HEADER_SIZE = 12
 
@@ -211,7 +211,7 @@ def parse_binary_command(in_buffer, is_response=True):
             binary_payload = binary_payload.tobytes()
         else:
             binary_payload = binary_payload.tostring()
-        split_arguments = binary_payload.split(NULL_CHAR, len(expected_cmd_params) - 1)
+        split_arguments = binary_payload.split(NULL_BYTE, len(expected_cmd_params) - 1)
     elif binary_payload:
         raise ProtocolError('Expected no binary payload: %s' % get_command_name(cmd_type))
 
@@ -254,7 +254,7 @@ def pack_binary_command(cmd_type, cmd_args, is_response=False):
     if compat.any(b'\0' in argument for argument in data_items[:-1]):
         raise ProtocolError('Received arguments with NULL byte in non-final argument')
 
-    binary_payload = NULL_CHAR.join(data_items)
+    binary_payload = NULL_BYTE.join(data_items)
 
     # Pack the header in the !4sII format then append the binary payload
     payload_size = len(binary_payload)
@@ -274,7 +274,7 @@ def parse_text_command(in_buffer):
     else:
         text_command, in_buffer = in_buffer.tostring().split(b'\n', 1)
 
-    if NULL_CHAR in text_command:
+    if NULL_BYTE in text_command:
         raise ProtocolError('Received unexpected character: %s' % text_command)
 
     # Fake gearman command "TEXT_COMMAND" used to process server admin client responses

--- a/gearman/protocol.py
+++ b/gearman/protocol.py
@@ -293,4 +293,4 @@ def pack_text_command(cmd_type, cmd_args):
     if cmd_line is None:
         raise ProtocolError('Did not receive arguments any valid arguments: %s' % cmd_args)
 
-    return compat.bytes_type(cmd_line)
+    return cmd_line

--- a/gearman/util.py
+++ b/gearman/util.py
@@ -59,7 +59,7 @@ def select(rlist, wlist, xlist, timeout=None):
 
     try:
         rd_list, wr_list, ex_list = select_lib.select(*select_args)
-    except select_lib.error, exc:
+    except select_lib.error as exc:
         # Ignore interrupted system call, reraise anything else
         if exc[0] != errno.EINTR:
             raise

--- a/gearman/worker.py
+++ b/gearman/worker.py
@@ -29,7 +29,7 @@ class GearmanWorker(GearmanConnectionManager):
         self._update_initial_state()
 
     def _update_initial_state(self):
-        self.handler_initial_state['abilities'] = self.worker_abilities.keys()
+        self.handler_initial_state['abilities'] = list(self.worker_abilities.keys())
         self.handler_initial_state['client_id'] = self.worker_client_id
 
     ########################################################
@@ -45,7 +45,7 @@ class GearmanWorker(GearmanConnectionManager):
         self._update_initial_state()
 
         for command_handler in self.handler_to_connection_map.keys():
-            command_handler.set_abilities(list(self.handler_initial_state['abilities']))
+            command_handler.set_abilities(self.handler_initial_state['abilities'])
 
         return task
 
@@ -55,7 +55,7 @@ class GearmanWorker(GearmanConnectionManager):
         self._update_initial_state()
 
         for command_handler in self.handler_to_connection_map.keys():
-            command_handler.set_abilities(list(self.handler_initial_state['abilities']))
+            command_handler.set_abilities(self.handler_initial_state['abilities'])
 
         return task
 

--- a/gearman/worker.py
+++ b/gearman/worker.py
@@ -44,8 +44,8 @@ class GearmanWorker(GearmanConnectionManager):
         self.worker_abilities[task] = callback_function
         self._update_initial_state()
 
-        for command_handler in self.handler_to_connection_map.iterkeys():
-            command_handler.set_abilities(self.handler_initial_state['abilities'])
+        for command_handler in self.handler_to_connection_map.keys():
+            command_handler.set_abilities(list(self.handler_initial_state['abilities']))
 
         return task
 
@@ -54,8 +54,8 @@ class GearmanWorker(GearmanConnectionManager):
         self.worker_abilities.pop(task, None)
         self._update_initial_state()
 
-        for command_handler in self.handler_to_connection_map.iterkeys():
-            command_handler.set_abilities(self.handler_initial_state['abilities'])
+        for command_handler in self.handler_to_connection_map.keys():
+            command_handler.set_abilities(list(self.handler_initial_state['abilities']))
 
         return task
 
@@ -64,7 +64,7 @@ class GearmanWorker(GearmanConnectionManager):
         self.worker_client_id = client_id
         self._update_initial_state()
 
-        for command_handler in self.handler_to_connection_map.iterkeys():
+        for command_handler in self.handler_to_connection_map.keys():
             command_handler.set_client_id(self.handler_initial_state['client_id'])
 
         return client_id

--- a/gearman/worker_handler.py
+++ b/gearman/worker_handler.py
@@ -4,6 +4,7 @@ from gearman.command_handler import GearmanCommandHandler
 from gearman.errors import InvalidWorkerState
 from gearman.protocol import GEARMAN_COMMAND_PRE_SLEEP, GEARMAN_COMMAND_RESET_ABILITIES, GEARMAN_COMMAND_CAN_DO, GEARMAN_COMMAND_SET_CLIENT_ID, GEARMAN_COMMAND_GRAB_JOB_UNIQ, \
     GEARMAN_COMMAND_WORK_STATUS, GEARMAN_COMMAND_WORK_COMPLETE, GEARMAN_COMMAND_WORK_FAIL, GEARMAN_COMMAND_WORK_EXCEPTION, GEARMAN_COMMAND_WORK_WARNING, GEARMAN_COMMAND_WORK_DATA
+from gearman import compat
 
 gearman_logger = logging.getLogger(__name__)
 
@@ -51,7 +52,9 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
     def send_job_status(self, current_job, numerator, denominator):
         assert type(numerator) in (int, float), 'Numerator must be a numeric value'
         assert type(denominator) in (int, float), 'Denominator must be a numeric value'
-        self.send_command(GEARMAN_COMMAND_WORK_STATUS, job_handle=current_job.handle, numerator=str(numerator), denominator=str(denominator))
+        numerator_bytes = compat.text_type(numerator).encode('ascii')
+        denominator_bytes = compat.text_type(denominator).encode('ascii')
+        self.send_command(GEARMAN_COMMAND_WORK_STATUS, job_handle=current_job.handle, numerator=numerator_bytes, denominator=denominator_bytes)
 
     def send_job_complete(self, current_job, data):
         """Removes a job from the queue if its backgrounded"""

--- a/gearman/worker_handler.py
+++ b/gearman/worker_handler.py
@@ -24,7 +24,7 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
 
     def initial_state(self, abilities=None, client_id=None):
         self.set_client_id(client_id)
-        self.set_abilities(abilities)
+        self.set_abilities(list(abilities))
 
         self._sleep()
 

--- a/gearman/worker_handler.py
+++ b/gearman/worker_handler.py
@@ -24,7 +24,7 @@ class GearmanWorkerCommandHandler(GearmanCommandHandler):
 
     def initial_state(self, abilities=None, client_id=None):
         self.set_client_id(client_id)
-        self.set_abilities(list(abilities))
+        self.set_abilities(abilities)
 
         self._sleep()
 

--- a/tests/_core_testing.py
+++ b/tests/_core_testing.py
@@ -63,11 +63,11 @@ class _GearmanAbstractTest(unittest.TestCase):
         self.setup_connection()
         self.setup_command_handler()
 
-    def setup_connection_manager(self):
+    def setup_connection_manager(self, *args, **kwargs):
         testing_attributes = {'command_handler_class': self.command_handler_class, 'connection_class': self.connection_class}
         testing_client_class = type('MockGearmanTestingClient', (self.connection_manager_class, ), testing_attributes)
 
-        self.connection_manager = testing_client_class()
+        self.connection_manager = testing_client_class(*args, **kwargs)
 
     def setup_connection(self):
         self.connection = self.connection_class()

--- a/tests/_core_testing.py
+++ b/tests/_core_testing.py
@@ -78,7 +78,11 @@ class _GearmanAbstractTest(unittest.TestCase):
         self.command_handler = self.connection_manager.connection_to_handler_map[self.connection]
 
     def generate_job(self):
-        return self.job_class(self.connection, handle=str(random.random()), task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        return self.job_class(self.connection,
+                              handle=str(random.random()).encode('ascii'),
+                              task='__test_ability__'.encode('ascii'),
+                              unique=str(random.random()).encode('ascii'),
+                              data=str(random.random()).encode('ascii'))
 
     def generate_job_dict(self):
         current_job = self.generate_job()
@@ -86,7 +90,11 @@ class _GearmanAbstractTest(unittest.TestCase):
 
     def generate_job_request(self, priority=PRIORITY_NONE, background=False):
         job_handle = str(random.random())
-        current_job = self.job_class(connection=self.connection, handle=job_handle, task='__test_ability__', unique=str(random.random()), data=str(random.random()))
+        current_job = self.job_class(connection=self.connection,
+                                     handle=job_handle,
+                                     task='__test_ability__'.encode('ascii'),
+                                     unique=str(random.random()).encode('ascii'),
+                                     data=str(random.random()).encode('ascii'))
         current_request = self.job_request_class(current_job, initial_priority=priority, background=background)
 
         self.assertEqual(current_request.state, JOB_UNKNOWN)

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -32,7 +32,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
 
         self.command_handler.recv_command(GEARMAN_COMMAND_ECHO_RES, data=ECHO_STRING)
         server_response = self.pop_response(GEARMAN_COMMAND_ECHO_REQ)
-        self.assertEquals(server_response, ECHO_STRING)
+        self.assertEqual(server_response, ECHO_STRING)
 
     def test_state_and_protocol_errors_for_status(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_STATUS)
@@ -46,7 +46,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response('.')
 
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_STATUS)
-        self.assertEquals(server_response, tuple())
+        self.assertEqual(server_response, tuple())
 
     def test_multiple_status(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_STATUS)
@@ -55,18 +55,18 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response('.')
 
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_STATUS)
-        self.assertEquals(len(server_response), 2)
+        self.assertEqual(len(server_response), 2)
 
         test_response, another_response = server_response
-        self.assertEquals(test_response['task'], 'test_function')
-        self.assertEquals(test_response['queued'], 1)
-        self.assertEquals(test_response['running'], 5)
-        self.assertEquals(test_response['workers'],  17)
+        self.assertEqual(test_response['task'], 'test_function')
+        self.assertEqual(test_response['queued'], 1)
+        self.assertEqual(test_response['running'], 5)
+        self.assertEqual(test_response['workers'],  17)
 
-        self.assertEquals(another_response['task'], 'another_function')
-        self.assertEquals(another_response['queued'], 2)
-        self.assertEquals(another_response['running'], 4)
-        self.assertEquals(another_response['workers'],  23)
+        self.assertEqual(another_response['task'], 'another_function')
+        self.assertEqual(another_response['queued'], 2)
+        self.assertEqual(another_response['running'], 4)
+        self.assertEqual(another_response['workers'],  23)
 
     def test_version(self):
         expected_version = '0.12345'
@@ -75,7 +75,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response(expected_version)
 
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_VERSION)
-        self.assertEquals(expected_version, server_response)
+        self.assertEqual(expected_version, server_response)
 
     def test_state_and_protocol_errors_for_workers(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_WORKERS)
@@ -90,7 +90,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response('.')
 
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_WORKERS)
-        self.assertEquals(server_response, tuple())
+        self.assertEqual(server_response, tuple())
 
     def test_multiple_workers(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_WORKERS)
@@ -99,18 +99,18 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response('.')
 
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_WORKERS)
-        self.assertEquals(len(server_response), 2)
+        self.assertEqual(len(server_response), 2)
 
         test_response, another_response = server_response
-        self.assertEquals(test_response['file_descriptor'], '12')
-        self.assertEquals(test_response['ip'], 'IP-A')
-        self.assertEquals(test_response['client_id'], 'CLIENT-A')
-        self.assertEquals(test_response['tasks'],  ('function-A', 'function-B'))
+        self.assertEqual(test_response['file_descriptor'], '12')
+        self.assertEqual(test_response['ip'], 'IP-A')
+        self.assertEqual(test_response['client_id'], 'CLIENT-A')
+        self.assertEqual(test_response['tasks'],  ('function-A', 'function-B'))
 
-        self.assertEquals(another_response['file_descriptor'], '13')
-        self.assertEquals(another_response['ip'], 'IP-B')
-        self.assertEquals(another_response['client_id'], 'CLIENT-B')
-        self.assertEquals(another_response['tasks'],  ('function-C', ))
+        self.assertEqual(another_response['file_descriptor'], '13')
+        self.assertEqual(another_response['ip'], 'IP-B')
+        self.assertEqual(another_response['client_id'], 'CLIENT-B')
+        self.assertEqual(another_response['tasks'],  ('function-C', ))
 
     def test_maxqueue(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_MAXQUEUE)
@@ -121,7 +121,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
 
         self.recv_server_response('OK')
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_MAXQUEUE)
-        self.assertEquals(server_response, 'OK')
+        self.assertEqual(server_response, 'OK')
 
     def test_shutdown(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_SHUTDOWN)
@@ -131,7 +131,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
 
         self.recv_server_response(None)
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_SHUTDOWN)
-        self.assertEquals(server_response, None)
+        self.assertEqual(server_response, None)
 
     def send_server_command(self, expected_command):
         self.command_handler.send_text_command(expected_command)
@@ -145,7 +145,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
 
     def pop_response(self, expected_command):
         server_cmd, server_response = self.command_handler.pop_response()
-        self.assertEquals(expected_command, server_cmd)
+        self.assertEqual(expected_command, server_cmd)
 
         return server_response
 

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -15,6 +15,7 @@ from gearman.protocol import (
     GEARMAN_SERVER_COMMAND_SHUTDOWN,
     GEARMAN_SERVER_COMMAND_GETPID,
     GEARMAN_SERVER_COMMAND_SHOW_JOBS,
+    GEARMAN_SERVER_COMMAND_SHOW_UNIQUE_JOBS,
 )
 
 from tests._core_testing import _GearmanAbstractTest, MockGearmanConnectionManager, MockGearmanConnection
@@ -152,6 +153,17 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
             'queued': 1,
             'canceled': 1,
             'enabled': 1,
+        })
+
+    def test_show_unique_jobs(self):
+        self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_UNIQUE_JOBS)
+
+        self.recv_server_response('handle1,handle2')
+        self.recv_server_response('.')
+
+        server_response = self.pop_response(GEARMAN_SERVER_COMMAND_SHOW_UNIQUE_JOBS)
+        self.assertEqual(server_response[0], {
+            'unique': 'handle1,handle2',
         })
 
     def test_shutdown(self):

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -4,8 +4,18 @@ from gearman.admin_client import GearmanAdminClient, ECHO_STRING
 from gearman.admin_client_handler import GearmanAdminClientCommandHandler
 
 from gearman.errors import InvalidAdminClientState, ProtocolError
-from gearman.protocol import GEARMAN_COMMAND_ECHO_RES, GEARMAN_COMMAND_ECHO_REQ, GEARMAN_COMMAND_TEXT_COMMAND, \
-    GEARMAN_SERVER_COMMAND_STATUS, GEARMAN_SERVER_COMMAND_VERSION, GEARMAN_SERVER_COMMAND_WORKERS, GEARMAN_SERVER_COMMAND_MAXQUEUE, GEARMAN_SERVER_COMMAND_SHUTDOWN, GEARMAN_SERVER_COMMAND_GETPID
+from gearman.protocol import (
+    GEARMAN_COMMAND_ECHO_RES,
+    GEARMAN_COMMAND_ECHO_REQ,
+    GEARMAN_COMMAND_TEXT_COMMAND,
+    GEARMAN_SERVER_COMMAND_STATUS,
+    GEARMAN_SERVER_COMMAND_VERSION,
+    GEARMAN_SERVER_COMMAND_WORKERS,
+    GEARMAN_SERVER_COMMAND_MAXQUEUE,
+    GEARMAN_SERVER_COMMAND_SHUTDOWN,
+    GEARMAN_SERVER_COMMAND_GETPID,
+    GEARMAN_SERVER_COMMAND_SHOW_JOBS,
+)
 
 from tests._core_testing import _GearmanAbstractTest, MockGearmanConnectionManager, MockGearmanConnection
 
@@ -129,6 +139,20 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.recv_server_response('OK')
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_GETPID)
         self.assertEqual(server_response, 'OK')
+
+    def test_showjobs(self):
+        self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_JOBS)
+
+        self.recv_server_response('handle\t1\t1\t1')
+        self.recv_server_response('.')
+
+        server_response = self.pop_response(GEARMAN_SERVER_COMMAND_SHOW_JOBS)
+        self.assertEqual(server_response[0], {
+            'handle': 'handle',
+            'queued': 1,
+            'canceled': 1,
+            'enabled': 1,
+        })
 
     def test_shutdown(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_SHUTDOWN)

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -141,7 +141,7 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_GETPID)
         self.assertEqual(server_response, 'OK')
 
-    def test_showjobs(self):
+    def test_show_jobs(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_JOBS)
 
         self.recv_server_response('handle\t1\t1\t1')

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -5,7 +5,7 @@ from gearman.admin_client_handler import GearmanAdminClientCommandHandler
 
 from gearman.errors import InvalidAdminClientState, ProtocolError
 from gearman.protocol import GEARMAN_COMMAND_ECHO_RES, GEARMAN_COMMAND_ECHO_REQ, GEARMAN_COMMAND_TEXT_COMMAND, \
-    GEARMAN_SERVER_COMMAND_STATUS, GEARMAN_SERVER_COMMAND_VERSION, GEARMAN_SERVER_COMMAND_WORKERS, GEARMAN_SERVER_COMMAND_MAXQUEUE, GEARMAN_SERVER_COMMAND_SHUTDOWN
+    GEARMAN_SERVER_COMMAND_STATUS, GEARMAN_SERVER_COMMAND_VERSION, GEARMAN_SERVER_COMMAND_WORKERS, GEARMAN_SERVER_COMMAND_MAXQUEUE, GEARMAN_SERVER_COMMAND_SHUTDOWN, GEARMAN_SERVER_COMMAND_GETPID
 
 from tests._core_testing import _GearmanAbstractTest, MockGearmanConnectionManager, MockGearmanConnection
 
@@ -121,6 +121,13 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
 
         self.recv_server_response('OK')
         server_response = self.pop_response(GEARMAN_SERVER_COMMAND_MAXQUEUE)
+        self.assertEqual(server_response, 'OK')
+
+    def test_getpid(self):
+        self.send_server_command(GEARMAN_SERVER_COMMAND_GETPID)
+
+        self.recv_server_response('OK')
+        server_response = self.pop_response(GEARMAN_SERVER_COMMAND_GETPID)
         self.assertEqual(server_response, 'OK')
 
     def test_shutdown(self):

--- a/tests/admin_client_tests.py
+++ b/tests/admin_client_tests.py
@@ -155,6 +155,11 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
             'enabled': 1,
         })
 
+    def test_show_jobs_invalid(self):
+        self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_JOBS)
+
+        self.assertRaises(ProtocolError, self.recv_server_response, 'invalid\tresponse')
+
     def test_show_unique_jobs(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_UNIQUE_JOBS)
 
@@ -165,6 +170,11 @@ class CommandHandlerStateMachineTest(_GearmanAbstractTest):
         self.assertEqual(server_response[0], {
             'unique': 'handle1,handle2',
         })
+
+    def test_show_unique_jobs_invalid(self):
+        self.send_server_command(GEARMAN_SERVER_COMMAND_SHOW_UNIQUE_JOBS)
+
+        self.assertRaises(ProtocolError, self.recv_server_response, 'invalid\tresponse')
 
     def test_shutdown(self):
         self.send_server_command(GEARMAN_SERVER_COMMAND_SHUTDOWN)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -28,6 +28,22 @@ class ClientTest(_GearmanAbstractTest):
         super(ClientTest, self).tearDown()
         self.connection_manager.handle_connection_activity = self.original_handle_connection_activity
 
+    def test_create_client_with_hosts_tuple(self):
+        self.setup_connection_manager()
+        self.connection_manager.add_connection(('127.0.0.1', 4730))
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+
+    def test_create_client_with_hosts_string(self):
+        self.setup_connection_manager(['127.0.0.1:4730'])
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+
+    def test_create_client_with_hosts_string_with_default_port(self):
+        self.setup_connection_manager(['127.0.0.1'])
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
+        self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+
     def generate_job_request(self, submitted=True, accepted=True):
         current_request = super(ClientTest, self).generate_job_request()
         if submitted or accepted:

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -211,7 +211,7 @@ class ClientTest(_GearmanAbstractTest):
         def multiple_job_updates(rx_conns, wr_conns, ex_conns):
             # Only give a single status update and have the 3rd job handle timeout
             if self.update_requests:
-                self.command_handler.recv_command(GEARMAN_COMMAND_WORK_COMPLETE, job_handle=completed_request.job.handle, data='12345')
+                self.command_handler.recv_command(GEARMAN_COMMAND_WORK_COMPLETE, job_handle=completed_request.job.handle, data=b'12345')
                 self.command_handler.recv_command(GEARMAN_COMMAND_WORK_FAIL, job_handle=failed_request.job.handle)
                 self.update_requests = False
 
@@ -226,7 +226,7 @@ class ClientTest(_GearmanAbstractTest):
 
         self.assert_jobs_equal(finished_completed_request.job, completed_request.job)
         self.assertEqual(finished_completed_request.state, JOB_COMPLETE)
-        self.assertEqual(finished_completed_request.result, '12345')
+        self.assertEqual(finished_completed_request.result, b'12345')
         self.assertFalse(finished_completed_request.timed_out)
         #self.assertTrue(finished_completed_request.job.handle not in self.command_handler.handle_to_request_map)
 
@@ -394,7 +394,7 @@ class ClientCommandHandlerStateMachineTest(_GearmanAbstractTest):
         current_request = self.generate_job_request()
 
         job_handle = current_request.job.handle
-        new_data = str(random.random())
+        new_data = str(random.random()).encode('ascii')
 
         # Test WORK_DATA
         self.command_handler.recv_command(GEARMAN_COMMAND_WORK_DATA, job_handle=job_handle, data=new_data)
@@ -416,7 +416,7 @@ class ClientCommandHandlerStateMachineTest(_GearmanAbstractTest):
         current_request = self.generate_job_request()
 
         job_handle = current_request.job.handle
-        new_data = str(random.random())
+        new_data = str(random.random()).encode('ascii')
         self.command_handler.recv_command(GEARMAN_COMMAND_WORK_COMPLETE, job_handle=job_handle, data=new_data)
 
         self.assertEqual(current_request.result, new_data)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -36,7 +36,7 @@ class ClientTest(_GearmanAbstractTest):
 
         if submitted and accepted:
             self.command_handler.recv_command(GEARMAN_COMMAND_JOB_CREATED, job_handle=current_request.job.handle)
-            self.assert_(current_request.job.handle in self.command_handler.handle_to_request_map)
+            self.assertTrue(current_request.job.handle in self.command_handler.handle_to_request_map)
 
         return current_request
 
@@ -56,7 +56,7 @@ class ClientTest(_GearmanAbstractTest):
 
         # When we first create our request, our client shouldn't know anything about it
         current_request = self.generate_job_request(submitted=False, accepted=False)
-        self.failIf(current_request in self.connection_manager.request_to_rotating_connection_queue)
+        self.assertFalse(current_request in self.connection_manager.request_to_rotating_connection_queue)
 
         # Make sure that when we start up, we get our good connection
         chosen_connection = self.connection_manager.establish_request_connection(current_request)
@@ -117,7 +117,7 @@ class ClientTest(_GearmanAbstractTest):
                 # So we don't bail out of the "self.connection_manager.poll_connections_until_stopped" loop
                 self.connection_manager.establish_connection(self.connection)
             else:
-                self.assertEquals(current_request.state, JOB_PENDING)
+                self.assertEqual(current_request.state, JOB_PENDING)
                 self.command_handler.recv_command(GEARMAN_COMMAND_JOB_CREATED, job_handle=current_request.job.handle)
 
             return rx_conns, wr_conns, ex_conns
@@ -132,8 +132,8 @@ class ClientTest(_GearmanAbstractTest):
         current_request.state = JOB_UNKNOWN
 
         accepted_jobs = self.connection_manager.wait_until_jobs_accepted([current_request])
-        self.assertEquals(current_request.state, JOB_CREATED)
-        self.assertEquals(current_request.connection_attempts, current_request.max_connection_attempts)
+        self.assertEqual(current_request.state, JOB_CREATED)
+        self.assertEqual(current_request.connection_attempts, current_request.max_connection_attempts)
 
         # Second pass should fail as we JUST exceed our max attempts
         self.connection_manager.current_failures = current_request.connection_attempts = 0
@@ -141,12 +141,12 @@ class ClientTest(_GearmanAbstractTest):
         current_request.state = JOB_UNKNOWN
 
         self.assertRaises(ExceededConnectionAttempts, self.connection_manager.wait_until_jobs_accepted, [current_request])
-        self.assertEquals(current_request.state, JOB_UNKNOWN)
-        self.assertEquals(current_request.connection_attempts, current_request.max_connection_attempts)
+        self.assertEqual(current_request.state, JOB_UNKNOWN)
+        self.assertEqual(current_request.connection_attempts, current_request.max_connection_attempts)
 
     def test_multiple_fg_job_submission(self):
         submitted_job_count = 5
-        expected_job_list = [self.generate_job() for _ in xrange(submitted_job_count)]
+        expected_job_list = [self.generate_job() for _ in range(submitted_job_count)]
         def mark_jobs_created(rx_conns, wr_conns, ex_conns):
             for current_job in expected_job_list:
                 self.command_handler.recv_command(GEARMAN_COMMAND_JOB_CREATED, job_handle=current_job.handle)
@@ -228,18 +228,18 @@ class ClientTest(_GearmanAbstractTest):
         self.assertEqual(finished_completed_request.state, JOB_COMPLETE)
         self.assertEqual(finished_completed_request.result, '12345')
         self.assertFalse(finished_completed_request.timed_out)
-        #self.assert_(finished_completed_request.job.handle not in self.command_handler.handle_to_request_map)
+        #self.assertTrue(finished_completed_request.job.handle not in self.command_handler.handle_to_request_map)
 
         self.assert_jobs_equal(finished_failed_request.job, failed_request.job)
         self.assertEqual(finished_failed_request.state, JOB_FAILED)
         self.assertEqual(finished_failed_request.result, None)
         self.assertFalse(finished_failed_request.timed_out)
-        #self.assert_(finished_failed_request.job.handle not in self.command_handler.handle_to_request_map)
+        #self.assertTrue(finished_failed_request.job.handle not in self.command_handler.handle_to_request_map)
 
         self.assertEqual(finished_timeout_request.state, JOB_CREATED)
         self.assertEqual(finished_timeout_request.result, None)
         self.assertTrue(finished_timeout_request.timed_out)
-        self.assert_(finished_timeout_request.job.handle in self.command_handler.handle_to_request_map)
+        self.assertTrue(finished_timeout_request.job.handle in self.command_handler.handle_to_request_map)
 
     def test_get_job_status(self):
         single_request = self.generate_job_request()
@@ -252,7 +252,7 @@ class ClientTest(_GearmanAbstractTest):
 
         job_request = self.connection_manager.get_job_status(single_request)
         request_status = job_request.status
-        self.failUnless(request_status)
+        self.assertTrue(request_status)
         self.assertTrue(request_status['known'])
         self.assertFalse(request_status['running'])
         self.assertEqual(request_status['numerator'], 0)
@@ -272,13 +272,13 @@ class ClientTest(_GearmanAbstractTest):
 
         job_request = self.connection_manager.get_job_status(single_request)
         request_status = job_request.status
-        self.failUnless(request_status)
+        self.assertTrue(request_status)
         self.assertFalse(request_status['known'])
         self.assertFalse(request_status['running'])
         self.assertEqual(request_status['numerator'], 0)
         self.assertEqual(request_status['denominator'], 1)
         self.assertFalse(job_request.timed_out)
-        #self.assert_(current_handle not in self.command_handler.handle_to_request_map)
+        #self.assertTrue(current_handle not in self.command_handler.handle_to_request_map)
 
     def test_get_job_status_timeout(self):
         single_request = self.generate_job_request()

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -33,16 +33,19 @@ class ClientTest(_GearmanAbstractTest):
         self.connection_manager.add_connection(('127.0.0.1', 4730))
         self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
         self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+        self.assertEqual(self.connection_manager.connection_list[0].get_address(), ('127.0.0.1', 4730))
 
     def test_create_client_with_hosts_string(self):
         self.setup_connection_manager(['127.0.0.1:4730'])
         self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
         self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+        self.assertEqual(self.connection_manager.connection_list[0].get_address(), ('127.0.0.1', 4730))
 
     def test_create_client_with_hosts_string_with_default_port(self):
         self.setup_connection_manager(['127.0.0.1'])
         self.assertEqual(self.connection_manager.connection_list[0].gearman_host, '127.0.0.1')
         self.assertEqual(self.connection_manager.connection_list[0].gearman_port, 4730)
+        self.assertEqual(self.connection_manager.connection_list[0].get_address(), ('127.0.0.1', 4730))
 
     def generate_job_request(self, submitted=True, accepted=True):
         current_request = super(ClientTest, self).generate_job_request()

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -25,47 +25,47 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
     # Begin parsing tests #
     #######################
     def test_parsing_errors(self):
-        malformed_command_buffer = "%sAAAABBBBCCCC"
+        malformed_command_buffer = b"AAAABBBBCCCC"
 
         # Raise malformed magic exceptions
         self.assertRaises(
             ProtocolError,
             protocol.parse_binary_command,
-            array.array("c", malformed_command_buffer % "DDDD")
+            array.array("b", b"DDDD" + malformed_command_buffer)
         )
         self.assertRaises(
             ProtocolError,
             protocol.parse_binary_command,
-            array.array("c", malformed_command_buffer % protocol.MAGIC_RES_STRING),
+            array.array("b", protocol.MAGIC_RES_STRING + malformed_command_buffer),
             is_response=False
         )
         self.assertRaises(
             ProtocolError,
             protocol.parse_binary_command,
-            array.array("c", malformed_command_buffer % protocol.MAGIC_REQ_STRING),
+            array.array("b", protocol.MAGIC_REQ_STRING + malformed_command_buffer),
             is_response=True
         )
 
         # Raise unknown command errors
         unassigned_gearman_command = 1234
         unknown_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, unassigned_gearman_command, 0)
-        unknown_command_buffer = array.array("c", unknown_command_buffer)
+        unknown_command_buffer = array.array("b", unknown_command_buffer)
         self.assertRaises(ProtocolError, protocol.parse_binary_command, unknown_command_buffer)
 
         # Raise an error on our imaginary GEARMAN_COMMAND_TEXT_COMMAND
-        imaginary_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_TEXT_COMMAND, 4, 'ABCD')
-        imaginary_command_buffer = array.array("c", imaginary_command_buffer)
+        imaginary_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_TEXT_COMMAND, 4, b'ABCD')
+        imaginary_command_buffer = array.array("b", imaginary_command_buffer)
         self.assertRaises(ProtocolError, protocol.parse_binary_command, imaginary_command_buffer)
 
         # Raise an error on receiving an unexpected payload
-        unexpected_payload_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_NOOP, 4, 'ABCD')
-        unexpected_payload_command_buffer = array.array("c", unexpected_payload_command_buffer)
+        unexpected_payload_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_NOOP, 4, b'ABCD')
+        unexpected_payload_command_buffer = array.array("b", unexpected_payload_command_buffer)
         self.assertRaises(ProtocolError, protocol.parse_binary_command, unexpected_payload_command_buffer)
 
     def test_parsing_request(self):
         # Test parsing a request for a job (server side parsing)
         grab_job_command_buffer = struct.pack('!4sII', protocol.MAGIC_REQ_STRING, protocol.GEARMAN_COMMAND_GRAB_JOB_UNIQ, 0)
-        grab_job_command_buffer = array.array("c", grab_job_command_buffer)
+        grab_job_command_buffer = array.array("b", grab_job_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(grab_job_command_buffer, is_response=False)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_GRAB_JOB_UNIQ)
         self.assertEqual(cmd_args, dict())
@@ -74,7 +74,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
     def test_parsing_without_enough_data(self):
         # Test that we return with nothing to do... received a partial packet
         not_enough_data_command_buffer = struct.pack('!4s', protocol.MAGIC_RES_STRING)
-        not_enough_data_command_buffer = array.array("c", not_enough_data_command_buffer)
+        not_enough_data_command_buffer = array.array("b", not_enough_data_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(not_enough_data_command_buffer)
         self.assertEqual(cmd_type, None)
         self.assertEqual(cmd_args, None)
@@ -82,7 +82,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         # Test that we return with nothing to do... received a partial packet (expected binary payload of size 4, got 0)
         not_enough_data_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4)
-        not_enough_data_command_buffer = array.array("c", not_enough_data_command_buffer)
+        not_enough_data_command_buffer = array.array("b", not_enough_data_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(not_enough_data_command_buffer)
         self.assertEqual(cmd_type, None)
         self.assertEqual(cmd_args, None)
@@ -90,27 +90,27 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
     def test_parsing_no_args(self):
         noop_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_NOOP, 0)
-        noop_command_buffer = array.array("c", noop_command_buffer)
+        noop_command_buffer = array.array("b", noop_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(noop_command_buffer)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_NOOP)
         self.assertEqual(cmd_args, dict())
         self.assertEqual(cmd_len, len(noop_command_buffer))
 
     def test_parsing_single_arg(self):
-        echoed_string = 'abcd'
+        echoed_string = b'abcd'
         echo_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4, echoed_string)
-        echo_command_buffer = array.array("c", echo_command_buffer)
+        echo_command_buffer = array.array("b", echo_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(echo_command_buffer)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
         self.assertEqual(cmd_args, dict(data=echoed_string))
         self.assertEqual(cmd_len, len(echo_command_buffer))
 
     def test_parsing_single_arg_with_extra_data(self):
-        echoed_string = 'abcd'
+        echoed_string = b'abcd'
         excess_bytes = 5
         excess_data = echoed_string + (protocol.NULL_CHAR * excess_bytes)
         excess_echo_command_buffer = struct.pack('!4sII9s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4, excess_data)
-        excess_echo_command_buffer = array.array("c", excess_echo_command_buffer)
+        excess_echo_command_buffer = array.array("b", excess_echo_command_buffer)
 
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(excess_echo_command_buffer)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
@@ -120,14 +120,14 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
     def test_parsing_multiple_args(self):
         # Tests ordered argument processing and proper NULL_CHAR splitting
         expected_data = protocol.NULL_CHAR * 4
-        binary_payload = protocol.NULL_CHAR.join(['test', 'function', 'identifier', expected_data])
+        binary_payload = protocol.NULL_CHAR.join([b'test', b'function', b'identifier', expected_data])
         payload_size = len(binary_payload)
 
         uniq_command_buffer = struct.pack('!4sII%ds' % payload_size, protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ, payload_size, binary_payload)
-        uniq_command_buffer = array.array("c", uniq_command_buffer)
+        uniq_command_buffer = array.array("b", uniq_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(uniq_command_buffer)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ)
-        self.assertEqual(cmd_args, dict(job_handle='test', task='function', unique='identifier', data=expected_data))
+        self.assertEqual(cmd_args, dict(job_handle=b'test', task=b'function', unique=b'identifier', data=expected_data))
         self.assertEqual(cmd_len, len(uniq_command_buffer))
 
     #######################
@@ -171,17 +171,17 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
         cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
-        cmd_args = dict(task='funct\x00ion', data='abcd', unique='12345')
+        cmd_args = dict(task=b'funct\x00ion', data=b'abcd', unique=b'12345')
         self.assertRaises(ProtocolError, protocol.pack_binary_command, cmd_type, cmd_args)
 
         # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
         cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
-        cmd_args = dict(task='function', data='ab\x00cd', unique='12345')
+        cmd_args = dict(task=b'function', data=b'ab\x00cd', unique=b'12345')
         protocol.pack_binary_command(cmd_type, cmd_args) # Should not raise, 'data' is last.
 
         # Assert we check for NULLs in all but the "last" argument, where last depends on the cmd_type.
         cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
-        cmd_args = dict(task='function', data='abcd', unique='123\x0045')
+        cmd_args = dict(task=b'function', data=b'abcd', unique=b'123\x0045')
         self.assertRaises(ProtocolError, protocol.pack_binary_command, cmd_type, cmd_args)
 
     def test_packing_response(self):
@@ -203,7 +203,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
     def test_packing_single_arg(self):
         cmd_type = protocol.GEARMAN_COMMAND_ECHO_REQ
-        cmd_args = dict(data='abcde')
+        cmd_args = dict(data=b'abcde')
 
         expected_payload_size = len(cmd_args['data'])
         expected_format = '!4sII%ds' % expected_payload_size
@@ -214,7 +214,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
     def test_packing_multiple_args(self):
         cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
-        cmd_args = dict(task='function', unique='12345', data='abcd')
+        cmd_args = dict(task=b'function', unique=b'12345', data=b'abcd')
 
         ordered_parameters = [cmd_args['task'], cmd_args['unique'], cmd_args['data']]
 
@@ -231,31 +231,37 @@ class ProtocolTextCommandsTest(unittest.TestCase):
     # Begin parsing tests #
     #######################
     def test_parsing_errors(self):
-        received_data = array.array("c", "Hello\x00there\n")
+        received_data = array.array("b", b"Hello\x00there\n")
         self.assertRaises(ProtocolError, protocol.parse_text_command, received_data)
 
     def test_parsing_without_enough_data(self):
-        received_data = array.array("c", "Hello there")
+        received_data = array.array("b", b"Hello there")
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
         self.assertEqual(cmd_type, None)
         self.assertEqual(cmd_response, None)
         self.assertEqual(cmd_len, 0)
 
     def test_parsing_single_line(self):
-        received_data = array.array("c", "Hello there\n")
+        received_data = array.array("b", b"Hello there\n")
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
-        self.assertEqual(cmd_response, dict(raw_text=received_data.tostring().strip()))
+        if hasattr(received_data, 'tobytes'):
+            self.assertEqual(cmd_response, dict(raw_text=received_data.tobytes().strip()))
+        else:
+            self.assertEqual(cmd_response, dict(raw_text=received_data.tostring().strip()))
         self.assertEqual(cmd_len, len(received_data))
 
     def test_parsing_multi_line(self):
-        sentence_one = array.array("c", "Hello there\n")
-        sentence_two = array.array("c", "My name is bob\n")
+        sentence_one = array.array("b", b"Hello there\n")
+        sentence_two = array.array("b", b"My name is bob\n")
         received_data = sentence_one + sentence_two
 
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
         self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
-        self.assertEqual(cmd_response, dict(raw_text=sentence_one.tostring().strip()))
+        if hasattr(sentence_one, 'tobytes'):
+            self.assertEqual(cmd_response, dict(raw_text=sentence_one.tobytes().strip()))
+        else:
+            self.assertEqual(cmd_response, dict(raw_text=sentence_one.tostring().strip()))
         self.assertEqual(cmd_len, len(sentence_one))
 
     def test_packing_errors(self):

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -1,5 +1,6 @@
 import array
 import struct
+import sys
 import unittest
 
 from gearman import protocol
@@ -9,6 +10,15 @@ from gearman.constants import JOB_PENDING, JOB_CREATED, JOB_FAILED, JOB_COMPLETE
 from gearman.errors import ConnectionError, ServerUnavailable, ProtocolError
 
 from tests._core_testing import _GearmanAbstractTest
+
+
+PY3 = sys.version_info >= (3, 0)
+
+if PY3:
+    unicode = str
+else:
+    unicode = unicode
+
 
 class ProtocolBinaryCommandsTest(unittest.TestCase):
     #######################
@@ -57,43 +67,43 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         grab_job_command_buffer = struct.pack('!4sII', protocol.MAGIC_REQ_STRING, protocol.GEARMAN_COMMAND_GRAB_JOB_UNIQ, 0)
         grab_job_command_buffer = array.array("c", grab_job_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(grab_job_command_buffer, is_response=False)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_GRAB_JOB_UNIQ)
-        self.assertEquals(cmd_args, dict())
-        self.assertEquals(cmd_len, len(grab_job_command_buffer))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_GRAB_JOB_UNIQ)
+        self.assertEqual(cmd_args, dict())
+        self.assertEqual(cmd_len, len(grab_job_command_buffer))
 
     def test_parsing_without_enough_data(self):
         # Test that we return with nothing to do... received a partial packet
         not_enough_data_command_buffer = struct.pack('!4s', protocol.MAGIC_RES_STRING)
         not_enough_data_command_buffer = array.array("c", not_enough_data_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(not_enough_data_command_buffer)
-        self.assertEquals(cmd_type, None)
-        self.assertEquals(cmd_args, None)
-        self.assertEquals(cmd_len, 0)
+        self.assertEqual(cmd_type, None)
+        self.assertEqual(cmd_args, None)
+        self.assertEqual(cmd_len, 0)
 
         # Test that we return with nothing to do... received a partial packet (expected binary payload of size 4, got 0)
         not_enough_data_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4)
         not_enough_data_command_buffer = array.array("c", not_enough_data_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(not_enough_data_command_buffer)
-        self.assertEquals(cmd_type, None)
-        self.assertEquals(cmd_args, None)
-        self.assertEquals(cmd_len, 0)
+        self.assertEqual(cmd_type, None)
+        self.assertEqual(cmd_args, None)
+        self.assertEqual(cmd_len, 0)
 
     def test_parsing_no_args(self):
         noop_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_NOOP, 0)
         noop_command_buffer = array.array("c", noop_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(noop_command_buffer)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_NOOP)
-        self.assertEquals(cmd_args, dict())
-        self.assertEquals(cmd_len, len(noop_command_buffer))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_NOOP)
+        self.assertEqual(cmd_args, dict())
+        self.assertEqual(cmd_len, len(noop_command_buffer))
 
     def test_parsing_single_arg(self):
         echoed_string = 'abcd'
         echo_command_buffer = struct.pack('!4sII4s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4, echoed_string)
         echo_command_buffer = array.array("c", echo_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(echo_command_buffer)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
-        self.assertEquals(cmd_args, dict(data=echoed_string))
-        self.assertEquals(cmd_len, len(echo_command_buffer))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
+        self.assertEqual(cmd_args, dict(data=echoed_string))
+        self.assertEqual(cmd_len, len(echo_command_buffer))
 
     def test_parsing_single_arg_with_extra_data(self):
         echoed_string = 'abcd'
@@ -103,9 +113,9 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         excess_echo_command_buffer = array.array("c", excess_echo_command_buffer)
 
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(excess_echo_command_buffer)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
-        self.assertEquals(cmd_args, dict(data=echoed_string))
-        self.assertEquals(cmd_len, len(excess_echo_command_buffer) - excess_bytes)
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_ECHO_RES)
+        self.assertEqual(cmd_args, dict(data=echoed_string))
+        self.assertEqual(cmd_len, len(excess_echo_command_buffer) - excess_bytes)
 
     def test_parsing_multiple_args(self):
         # Tests ordered argument processing and proper NULL_CHAR splitting
@@ -116,9 +126,9 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         uniq_command_buffer = struct.pack('!4sII%ds' % payload_size, protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ, payload_size, binary_payload)
         uniq_command_buffer = array.array("c", uniq_command_buffer)
         cmd_type, cmd_args, cmd_len = protocol.parse_binary_command(uniq_command_buffer)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ)
-        self.assertEquals(cmd_args, dict(job_handle='test', task='function', unique='identifier', data=expected_data))
-        self.assertEquals(cmd_len, len(uniq_command_buffer))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ)
+        self.assertEqual(cmd_args, dict(job_handle='test', task='function', unique='identifier', data=expected_data))
+        self.assertEqual(cmd_len, len(uniq_command_buffer))
 
     #######################
     # Begin packing tests #
@@ -181,7 +191,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         expected_command_buffer = struct.pack('!4sII', protocol.MAGIC_RES_STRING, cmd_type, 0)
         packed_command_buffer = protocol.pack_binary_command(cmd_type, cmd_args, is_response=True)
-        self.assertEquals(packed_command_buffer, expected_command_buffer)
+        self.assertEqual(packed_command_buffer, expected_command_buffer)
 
     def test_packing_no_arg(self):
         cmd_type = protocol.GEARMAN_COMMAND_NOOP
@@ -189,7 +199,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         expected_command_buffer = struct.pack('!4sII', protocol.MAGIC_REQ_STRING, cmd_type, 0)
         packed_command_buffer = protocol.pack_binary_command(cmd_type, cmd_args)
-        self.assertEquals(packed_command_buffer, expected_command_buffer)
+        self.assertEqual(packed_command_buffer, expected_command_buffer)
 
     def test_packing_single_arg(self):
         cmd_type = protocol.GEARMAN_COMMAND_ECHO_REQ
@@ -200,7 +210,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         expected_command_buffer = struct.pack(expected_format, protocol.MAGIC_REQ_STRING, cmd_type, expected_payload_size, cmd_args['data'])
         packed_command_buffer = protocol.pack_binary_command(cmd_type, cmd_args)
-        self.assertEquals(packed_command_buffer, expected_command_buffer)
+        self.assertEqual(packed_command_buffer, expected_command_buffer)
 
     def test_packing_multiple_args(self):
         cmd_type = protocol.GEARMAN_COMMAND_SUBMIT_JOB
@@ -214,7 +224,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         expected_command_buffer = struct.pack(expected_format, protocol.MAGIC_REQ_STRING, cmd_type, expected_payload_size, expected_payload)
 
         packed_command_buffer = protocol.pack_binary_command(cmd_type, cmd_args)
-        self.assertEquals(packed_command_buffer, expected_command_buffer)
+        self.assertEqual(packed_command_buffer, expected_command_buffer)
 
 class ProtocolTextCommandsTest(unittest.TestCase):
 	#######################
@@ -227,16 +237,16 @@ class ProtocolTextCommandsTest(unittest.TestCase):
     def test_parsing_without_enough_data(self):
         received_data = array.array("c", "Hello there")
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
-        self.assertEquals(cmd_type, None)
-        self.assertEquals(cmd_response, None)
-        self.assertEquals(cmd_len, 0)
+        self.assertEqual(cmd_type, None)
+        self.assertEqual(cmd_response, None)
+        self.assertEqual(cmd_len, 0)
 
     def test_parsing_single_line(self):
         received_data = array.array("c", "Hello there\n")
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
-        self.assertEquals(cmd_response, dict(raw_text=received_data.tostring().strip()))
-        self.assertEquals(cmd_len, len(received_data))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
+        self.assertEqual(cmd_response, dict(raw_text=received_data.tostring().strip()))
+        self.assertEqual(cmd_len, len(received_data))
 
     def test_parsing_multi_line(self):
         sentence_one = array.array("c", "Hello there\n")
@@ -244,9 +254,9 @@ class ProtocolTextCommandsTest(unittest.TestCase):
         received_data = sentence_one + sentence_two
 
         cmd_type, cmd_response, cmd_len = protocol.parse_text_command(received_data)
-        self.assertEquals(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
-        self.assertEquals(cmd_response, dict(raw_text=sentence_one.tostring().strip()))
-        self.assertEquals(cmd_len, len(sentence_one))
+        self.assertEqual(cmd_type, protocol.GEARMAN_COMMAND_TEXT_COMMAND)
+        self.assertEqual(cmd_response, dict(raw_text=sentence_one.tostring().strip()))
+        self.assertEqual(cmd_len, len(sentence_one))
 
     def test_packing_errors(self):
         # Test bad command type
@@ -273,7 +283,7 @@ class ProtocolTextCommandsTest(unittest.TestCase):
         cmd_args = dict(raw_text=expected_string)
 
         packed_command = protocol.pack_text_command(cmd_type, cmd_args)
-        self.assertEquals(packed_command, expected_string)
+        self.assertEqual(packed_command, expected_string)
 
 class GearmanConnectionTest(unittest.TestCase):
     """Tests the base CommandHandler class that underpins all other CommandHandlerTests"""

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -108,7 +108,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
     def test_parsing_single_arg_with_extra_data(self):
         echoed_string = b'abcd'
         excess_bytes = 5
-        excess_data = echoed_string + (protocol.NULL_CHAR * excess_bytes)
+        excess_data = echoed_string + (protocol.NULL_BYTE * excess_bytes)
         excess_echo_command_buffer = struct.pack('!4sII9s', protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_ECHO_RES, 4, excess_data)
         excess_echo_command_buffer = array.array("b", excess_echo_command_buffer)
 
@@ -118,9 +118,9 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
         self.assertEqual(cmd_len, len(excess_echo_command_buffer) - excess_bytes)
 
     def test_parsing_multiple_args(self):
-        # Tests ordered argument processing and proper NULL_CHAR splitting
-        expected_data = protocol.NULL_CHAR * 4
-        binary_payload = protocol.NULL_CHAR.join([b'test', b'function', b'identifier', expected_data])
+        # Tests ordered argument processing and proper NULL_BYTE splitting
+        expected_data = protocol.NULL_BYTE * 4
+        binary_payload = protocol.NULL_BYTE.join([b'test', b'function', b'identifier', expected_data])
         payload_size = len(binary_payload)
 
         uniq_command_buffer = struct.pack('!4sII%ds' % payload_size, protocol.MAGIC_RES_STRING, protocol.GEARMAN_COMMAND_JOB_ASSIGN_UNIQ, payload_size, binary_payload)
@@ -218,7 +218,7 @@ class ProtocolBinaryCommandsTest(unittest.TestCase):
 
         ordered_parameters = [cmd_args['task'], cmd_args['unique'], cmd_args['data']]
 
-        expected_payload = protocol.NULL_CHAR.join(ordered_parameters)
+        expected_payload = protocol.NULL_BYTE.join(ordered_parameters)
         expected_payload_size = len(expected_payload)
         expected_format = '!4sII%ds' % expected_payload_size
         expected_command_buffer = struct.pack(expected_format, protocol.MAGIC_REQ_STRING, cmd_type, expected_payload_size, expected_payload)

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -284,7 +284,7 @@ class ProtocolTextCommandsTest(unittest.TestCase):
     # Begin packing tests #
     #######################
     def test_packing_single_line(self):
-        expected_string = 'Hello world'
+        expected_string = b'Hello world'
         cmd_type = protocol.GEARMAN_COMMAND_TEXT_COMMAND
         cmd_args = dict(raw_text=expected_string)
 

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -58,23 +58,23 @@ class WorkerTest(_GearmanAbstractWorkerTest):
 
         # Register a single callback
         self.connection_manager.register_task('fake_callback_one', fake_callback_one)
-        self.failUnless('fake_callback_one' in self.connection_manager.worker_abilities)
-        self.failIf('fake_callback_two' in self.connection_manager.worker_abilities)
+        self.assertTrue('fake_callback_one' in self.connection_manager.worker_abilities)
+        self.assertFalse('fake_callback_two' in self.connection_manager.worker_abilities)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_one'], fake_callback_one)
         self.assertEqual(self.command_handler._handler_abilities, ['fake_callback_one'])
 
         # Register another callback and make sure the command_handler sees the same functions
         self.connection_manager.register_task('fake_callback_two', fake_callback_two)
-        self.failUnless('fake_callback_one' in self.connection_manager.worker_abilities)
-        self.failUnless('fake_callback_two' in self.connection_manager.worker_abilities)
+        self.assertTrue('fake_callback_one' in self.connection_manager.worker_abilities)
+        self.assertTrue('fake_callback_two' in self.connection_manager.worker_abilities)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_one'], fake_callback_one)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_two'], fake_callback_two)
         self.assertEqual(self.command_handler._handler_abilities, ['fake_callback_one', 'fake_callback_two'])
 
         # Unregister a callback and make sure the command_handler sees the same functions
         self.connection_manager.unregister_task('fake_callback_one')
-        self.failIf('fake_callback_one' in self.connection_manager.worker_abilities)
-        self.failUnless('fake_callback_two' in self.connection_manager.worker_abilities)
+        self.assertFalse('fake_callback_one' in self.connection_manager.worker_abilities)
+        self.assertTrue('fake_callback_two' in self.connection_manager.worker_abilities)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_two'], fake_callback_two)
         self.assertEqual(self.command_handler._handler_abilities, ['fake_callback_two'])
 
@@ -149,7 +149,7 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
         self.connection_manager.establish_connection(self.connection)
 
         # When we attempt a new connection, make sure we get a new command handler
-        self.assertNotEquals(self.command_handler, self.connection_manager.connection_to_handler_map[self.connection])
+        self.assertNotEqual(self.command_handler, self.connection_manager.connection_to_handler_map[self.connection])
 
         self.assert_sent_client_id(expected_client_id)
         self.assert_sent_abilities(expected_abilities)

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -182,7 +182,7 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
 
         # Test GEARMAN_COMMAND_WORK_STATUS
         self.command_handler.send_job_status(current_job, 0, 1)
-        self.assert_sent_command(GEARMAN_COMMAND_WORK_STATUS, job_handle=current_job.handle, numerator='0', denominator='1')
+        self.assert_sent_command(GEARMAN_COMMAND_WORK_STATUS, job_handle=current_job.handle, numerator=b'0', denominator=b'1')
 
         # Test GEARMAN_COMMAND_WORK_COMPLETE
         self.command_handler.send_job_complete(current_job, b'completion data')

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -185,24 +185,24 @@ class WorkerCommandHandlerInterfaceTest(_GearmanAbstractWorkerTest):
         self.assert_sent_command(GEARMAN_COMMAND_WORK_STATUS, job_handle=current_job.handle, numerator='0', denominator='1')
 
         # Test GEARMAN_COMMAND_WORK_COMPLETE
-        self.command_handler.send_job_complete(current_job, 'completion data')
-        self.assert_sent_command(GEARMAN_COMMAND_WORK_COMPLETE, job_handle=current_job.handle, data='completion data')
+        self.command_handler.send_job_complete(current_job, b'completion data')
+        self.assert_sent_command(GEARMAN_COMMAND_WORK_COMPLETE, job_handle=current_job.handle, data=b'completion data')
 
         # Test GEARMAN_COMMAND_WORK_FAIL
         self.command_handler.send_job_failure(current_job)
         self.assert_sent_command(GEARMAN_COMMAND_WORK_FAIL, job_handle=current_job.handle)
 
         # Test GEARMAN_COMMAND_WORK_EXCEPTION
-        self.command_handler.send_job_exception(current_job, 'exception data')
-        self.assert_sent_command(GEARMAN_COMMAND_WORK_EXCEPTION, job_handle=current_job.handle, data='exception data')
+        self.command_handler.send_job_exception(current_job, b'exception data')
+        self.assert_sent_command(GEARMAN_COMMAND_WORK_EXCEPTION, job_handle=current_job.handle, data=b'exception data')
 
         # Test GEARMAN_COMMAND_WORK_DATA
-        self.command_handler.send_job_data(current_job, 'job data')
-        self.assert_sent_command(GEARMAN_COMMAND_WORK_DATA, job_handle=current_job.handle, data='job data')
+        self.command_handler.send_job_data(current_job, b'job data')
+        self.assert_sent_command(GEARMAN_COMMAND_WORK_DATA, job_handle=current_job.handle, data=b'job data')
 
         # Test GEARMAN_COMMAND_WORK_WARNING
-        self.command_handler.send_job_warning(current_job, 'job warning')
-        self.assert_sent_command(GEARMAN_COMMAND_WORK_WARNING, job_handle=current_job.handle, data='job warning')
+        self.command_handler.send_job_warning(current_job, b'job warning')
+        self.assert_sent_command(GEARMAN_COMMAND_WORK_WARNING, job_handle=current_job.handle, data=b'job warning')
 
 class WorkerCommandHandlerStateMachineTest(_GearmanAbstractWorkerTest):
     """Test multiple state transitions within a GearmanWorkerCommandHandler
@@ -214,11 +214,11 @@ class WorkerCommandHandlerStateMachineTest(_GearmanAbstractWorkerTest):
 
     def setup_connection_manager(self):
         super(WorkerCommandHandlerStateMachineTest, self).setup_connection_manager()
-        self.connection_manager.register_task('__test_ability__', None)
+        self.connection_manager.register_task(b'__test_ability__', None)
 
     def setup_command_handler(self):
         super(_GearmanAbstractWorkerTest, self).setup_command_handler()
-        self.assert_sent_abilities(['__test_ability__'])
+        self.assert_sent_abilities([b'__test_ability__'])
         self.assert_sent_command(GEARMAN_COMMAND_PRE_SLEEP)
 
     def test_wakeup_work(self):

--- a/tests/worker_tests.py
+++ b/tests/worker_tests.py
@@ -69,7 +69,8 @@ class WorkerTest(_GearmanAbstractWorkerTest):
         self.assertTrue('fake_callback_two' in self.connection_manager.worker_abilities)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_one'], fake_callback_one)
         self.assertEqual(self.connection_manager.worker_abilities['fake_callback_two'], fake_callback_two)
-        self.assertEqual(self.command_handler._handler_abilities, ['fake_callback_one', 'fake_callback_two'])
+        self.assertIn('fake_callback_one', self.command_handler._handler_abilities)
+        self.assertIn('fake_callback_two', self.command_handler._handler_abilities)
 
         # Unregister a callback and make sure the command_handler sees the same functions
         self.connection_manager.unregister_task('fake_callback_one')

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,5 @@
 envlist = py27, py32, py33, py34
 
 [testenv]
-commands = python -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests
+commands = coverage run -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests
+deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
 commands = coverage run -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27, py32, py33, py34
+
+[testenv]
+commands = python -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,6 @@ envlist = py26, py27, py32, py33, py34
 [testenv]
 commands = coverage run -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests
 deps = coverage
+
+[flake8]
+ignore = E501,F401


### PR DESCRIPTION
This commit makes all non-risky changes towards making the codebase compatible with Python 2.x and Python 3.x. More work is needed to make all tests pass and to ensure Unicode / bytes separation happens properly.

The changes made in this commit are:
- Clean up `DeprecationWarnings` regarding [outdated test method aliases](https://docs.python.org/2/library/unittest.html#deprecated-aliases).
- Changed various `.iterkeys()`, `.itervalues()` methods to be `.keys()` and `.values()` instead (which behave as expected in Python 3.x).
- Use new `exception Exception as exc` syntax instead of the outdated comma syntax for catching exceptions.
- Added three `list()` calls to ensure an assertion passes in `def set_abilities` in `worker_handler.py`. It may be possible to remove these `list()` calls and the assertion altogether but that should be done when going over the code for full Python 2.x and 3.x compatibility.
