### PR TITLE
remove handle_to_request_map entries manually

### DIFF
--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -61,7 +61,7 @@ class GearmanConnectionManager(object):
         host_list = host_list or []
         for element in host_list:
             # old style host:port pair
-            if isinstance(element, str):
+            if isinstance(element, basestring):
                 self.add_connection(element)
             elif isinstance(element, dict):
                 if not all (k in element for k in ('host', 'port', 'keyfile', 'certfile', 'ca_certs')):


### PR DESCRIPTION
- handle_to_request_map as weakref leads to keyError because entry is removed before finishing the job in async mode
- implemented as a dict, remove method should be implemented again to avoid memory leak

Additionally I have included the possibility of passing hostnames as unicode as currently only str is supported.
