### PR TITLE
allow hostnames to be passed as unicode in GearmanConnection

### DIFF
--- a/gearman/connection_manager.py
+++ b/gearman/connection_manager.py
@@ -61,7 +61,7 @@ class GearmanConnectionManager(object):
         host_list = host_list or []
         for element in host_list:
             # old style host:port pair
-            if isinstance(element, str):
+            if isinstance(element, basestring):
                 self.add_connection(element)
             elif isinstance(element, dict):
                 if not all (k in element for k in ('host', 'port', 'keyfile', 'certfile', 'ca_certs')):


### PR DESCRIPTION
Allow that gearman connections strings can be set as unicode 
