### PR TITLE
Clarify JOB_UNKNOWN source in docs

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -10,7 +10,7 @@ Function available to all examples::
             print "Job %s finished!  Result: %s - %s" % (job_request.job.unique, job_request.state, job_request.result)
         elif job_request.timed_out:
             print "Job %s timed out!" % job_request.unique
-        elif job_request.state == JOB_UNKNOWN:
+        elif job_request.state == gearman.client.JOB_UNKNOWN:
             print "Job %s connection failed!" % job_request.unique
 
 .. autoclass:: GearmanClient
@@ -69,7 +69,7 @@ Submitting jobs
         failed_requests = gm_client.submit_multiple_jobs(list_of_jobs, background=False)
 
         # Let's pretend our assigned requests' Gearman servers all failed
-        assert all(request.state == JOB_UNKNOWN for request in failed_requests), "All connections didn't fail!"
+        assert all(request.state == gearman.client.JOB_UNKNOWN for request in failed_requests), "All connections didn't fail!"
 
         # Let's pretend our assigned requests' don't fail but some simply timeout
         retried_connection_failed_requests = gm_client.submit_multiple_requests(failed_requests, wait_until_complete=True, poll_timeout=1.0)

--- a/gearman/client.py
+++ b/gearman/client.py
@@ -56,7 +56,7 @@ class GearmanClient(GearmanConnectionManager):
         * Blocks until our jobs are accepted (should be fast) OR times out
         * Optionally blocks until jobs are all complete
 
-        You MUST check the status of your requests after calling this function as "timed_out" or "state == JOB_UNKNOWN" maybe True
+        You MUST check the status of your requests after calling this function as "timed_out" or "state == gearman.client.JOB_UNKNOWN" maybe True
         """
         assert type(job_requests) in (list, tuple, set), "Expected multiple job requests, received 1?"
         stopwatch = gearman.util.Stopwatch(poll_timeout)


### PR DESCRIPTION
The sample code in the gearman.client docs did not specify where JOB_UNKNOWN was being imported from, and the snippet of code provided in the docs was invalid. Update docs to reflect where JOB_UNKNOWN can be imported from.
