### PR TITLE
Gearman 154 catch unexpected job handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ MANIFEST
 dist
 build
 *.swo
+
+# Testing
+.tox

--- a/gearman/__init__.py
+++ b/gearman/__init__.py
@@ -2,7 +2,7 @@
 Gearman API - Client, worker, and admin client interfaces
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 from gearman.admin_client import GearmanAdminClient
 from gearman.client import GearmanClient

--- a/gearman/client_handler.py
+++ b/gearman/client_handler.py
@@ -6,7 +6,7 @@ import weakref
 from gearman.command_handler import GearmanCommandHandler
 from gearman.constants import JOB_UNKNOWN, JOB_PENDING, JOB_CREATED, JOB_FAILED, JOB_COMPLETE
 from gearman.errors import InvalidClientState
-from gearman.protocol import GEARMAN_COMMAND_GET_STATUS, submit_cmd_for_background_priority
+from gearman.protocol import GEARMAN_COMMAND_GET_STATUS, submit_cmd_for_background_priority, get_command_name
 
 gearman_logger = logging.getLogger(__name__)
 
@@ -60,6 +60,17 @@ class GearmanClientCommandHandler(GearmanCommandHandler):
     def _assert_request_state(self, current_request, expected_state):
         if current_request.state != expected_state:
             raise InvalidClientState('Expected handle (%s) to be in state %r, got %r' % (current_request.job.handle, expected_state, current_request.state))
+
+    def recv_command(self, cmd_type, **cmd_args):
+        # GEARMAN-154 : KeyError occurs when we receive a job handle that is not in self.handle_to_request_map
+        # A possible reason is that the client timeout before it receives a JOB_CREATED when submitting a job.
+        # In this case, the request is no registered in the handle_to_request_map.`
+        # At some point later when the client receives a command that tries to access the map by an unknown job_handle,
+        # KeyError is raised. Need more investigation to find the actual reason.
+        try:
+            super(GearmanClientCommandHandler, self).recv_command(cmd_type, **cmd_args)
+        except KeyError as e:
+            gearman_logger.warning('Catched KeyError in %r %r : %r' % (get_command_name(cmd_type), cmd_args, e))
 
     def recv_job_created(self, job_handle):
         if not self.requests_awaiting_handles:

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    install_requires=[
+        'mock',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27
+
+[testenv]
+commands = python -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests


### PR DESCRIPTION
KeyError occurs when we receive a job handle that is not in self.handle_to_request_map
A possible reason is that the client timeout before it receives a JOB_CREATED when submitting a job.
In this case, the request is no registered in the handle_to_request_map.`
At some point later when the client receives a command that tries to access the map by an unknown job_handle,
KeyError is raised. Need more investigation to find the actual reason.
