### PR TITLE
Paiwei catch unexpected job handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ gearman/._*
 MANIFEST
 dist
 build
+*.swo
+
+# Testing
+.tox

--- a/gearman/__init__.py
+++ b/gearman/__init__.py
@@ -2,7 +2,7 @@
 Gearman API - Client, worker, and admin client interfaces
 """
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'
 
 from gearman.admin_client import GearmanAdminClient
 from gearman.client import GearmanClient

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    install_requires=[
+        'mock',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27
+
+[testenv]
+commands = python -m unittest tests.admin_client_tests tests.client_tests tests.protocol_tests tests.worker_tests


### PR DESCRIPTION
catch keyerror exception that caused by accessing an non-registered handle in the handle_to_request_map.
